### PR TITLE
[Feat] swagger 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-restclient")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.modulith:spring-modulith-starter-core")
     implementation("tools.jackson.module:jackson-module-kotlin")

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/PublicEndpoints.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/PublicEndpoints.kt
@@ -1,9 +1,21 @@
 package com.whatever.caro.auth.internal.config
 
 object PublicEndpoints {
-    val PATTERNS = listOf(
-        "/api/v1/auth/social-login",
-        "/api/v1/auth/refresh",
+    val SWAGGER = listOf(
+        "/swagger",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/v3/api-docs.yaml",
+    )
+
+    val MONITORING = listOf(
         "/actuator/**",
     )
+
+    val AUTH = listOf(
+        "/api/v1/auth/social-login",
+        "/api/v1/auth/refresh",
+    )
+
+    val PATTERNS: List<String> = AUTH + MONITORING + SWAGGER
 }

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
@@ -46,6 +46,7 @@ class SecurityConfig(
             }
 
             authorizeHttpRequests {
+                // staging 에서는 SwaggerSecurityConfig가 우선시되어 Basic Auth 필요
                 PublicEndpoints.PATTERNS.forEach { authorize(it, permitAll) }
                 authorize("/api/v1/auth/complete-registration", hasRole("SUSPENDED"))
                 authorize("/api/v1/nicknames/**", hasRole("SUSPENDED"))

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/SwaggerSecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/SwaggerSecurityConfig.kt
@@ -1,0 +1,55 @@
+package com.whatever.caro.auth.internal.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * staging 전용 Swagger Basic Auth SecurityFilterChain.
+ *
+ * - @Profile("staging") 으로 local/prod 에서는 빈 자체가 로드되지 않음
+ */
+@Configuration
+@Profile("staging")
+class SwaggerSecurityConfig {
+
+    @Bean
+    @Order(1)
+    fun swaggerSecurityFilterChain(
+        http: HttpSecurity,
+        @Value("\${app.swagger.auth.username:}") username: String,
+        @Value("\${app.swagger.auth.password:}") password: String,
+    ): SecurityFilterChain {
+        require(username.isNotBlank()) { "SWAGGER_USERNAME env var 가 설정되지 않았습니다" }
+        require(password.isNotBlank()) { "SWAGGER_PASSWORD env var 가 설정되지 않았습니다" }
+
+        // DelegatingPasswordEncoder 는 해시 알고리즘을 {bcrypt} 같은 prefix 로 식별하므로 prefix 필수.
+        val encodedPassword = "{bcrypt}" + BCryptPasswordEncoder().encode(password)
+        val userDetailsService = InMemoryUserDetailsManager(
+            User.withUsername(username)
+                .password(encodedPassword)
+                .roles("SWAGGER")
+                .build(),
+        )
+
+        http.userDetailsService(userDetailsService)
+        http {
+            securityMatcher(*PublicEndpoints.SWAGGER.toTypedArray())
+            csrf { disable() }
+            cors { disable() }
+            sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
+            httpBasic { realmName = "Caro Swagger (Staging)" }
+            authorizeHttpRequests { authorize(anyRequest, authenticated) }
+        }
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
@@ -6,7 +6,9 @@ import com.whatever.caro.auth.internal.web.request.CompleteRegistrationRequest
 import com.whatever.caro.auth.internal.web.request.LogoutRequest
 import com.whatever.caro.auth.internal.web.request.RefreshTokenRequest
 import com.whatever.caro.auth.internal.web.request.SocialLoginRequest
+import com.whatever.caro.common.openapi.PublicApi
 import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,11 +16,13 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Auth", description = "인증 / 세션 관리")
 @RestController
 @RequestMapping("/api/v1/auth")
 class AuthController(
     private val authService: AuthService,
 ) {
+    @PublicApi
     @PostMapping("/social-login")
     fun socialLogin(
         @Valid @RequestBody request: SocialLoginRequest,
@@ -36,6 +40,7 @@ class AuthController(
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
+    @PublicApi
     @PostMapping("/refresh")
     fun refreshToken(
         @Valid @RequestBody request: RefreshTokenRequest,

--- a/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
@@ -1,0 +1,41 @@
+package com.whatever.caro.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("!prod")
+class OpenApiConfig {
+
+    @Bean
+    fun caroOpenAPI(): OpenAPI =
+        OpenAPI()
+            .info(
+                Info()
+                    .title("Caro Backend API")
+                    .description("Flashcard backend REST API")
+                    .version("v1"),
+            )
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        BEARER_SCHEME_NAME,
+                        SecurityScheme()
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")
+                            .description("JWT Access Token"),
+                    ),
+            )
+            .addSecurityItem(SecurityRequirement().addList(BEARER_SCHEME_NAME))
+
+    companion object {
+        const val BEARER_SCHEME_NAME = "bearerAuth"
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/common/openapi/PublicApi.kt
+++ b/src/main/kotlin/com/whatever/caro/common/openapi/PublicApi.kt
@@ -1,0 +1,16 @@
+package com.whatever.caro.common.openapi
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
+
+/**
+ * 해당 엔드포인트가 인증 없이 접근 가능함을 Swagger UI 에 표시.
+ *
+ * 이 어노테이션은 문서화(Swagger UI)에만 영향을 줌.
+ * 실제 Spring Security 허용은 `PublicEndpoints.PATTERNS` 에 경로를 등록해야 함.
+ * `PublicEndpointsOpenApiConsistencyTest`에서 두 설정 간 정합성을 검증.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@MustBeDocumented
+@SecurityRequirements
+annotation class PublicApi

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -29,3 +29,9 @@ logging:
   level:
     root: INFO
     com.whatever.caro: INFO
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -25,3 +25,9 @@ management:
   tracing:
     sampling:
       probability: 1.0
+
+app:
+  swagger:
+    auth:
+      username: ${SWAGGER_USERNAME}
+      password: ${SWAGGER_PASSWORD}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -107,3 +107,16 @@ management:
           - "span_id"
           - "module.source"
           - "module.target"
+
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    path: /swagger
+    operations-sorter: alpha
+    tags-sorter: alpha
+    display-request-duration: true
+  packages-to-scan: com.whatever.caro
+  paths-to-match: /api/**, /v1/**

--- a/src/test/kotlin/com/whatever/caro/auth/internal/config/SwaggerStagingBasicAuthTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/config/SwaggerStagingBasicAuthTest.kt
@@ -1,0 +1,105 @@
+package com.whatever.caro.auth.internal.config
+
+import com.whatever.caro.TestcontainersConfiguration
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.util.Base64
+
+private fun basicAuthHeader(
+    user: String,
+    pass: String,
+): String = "Basic " + Base64.getEncoder().encodeToString("$user:$pass".toByteArray())
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("staging")
+@Import(TestcontainersConfiguration::class)
+@TestPropertySource(
+    properties = [
+        "JWT_SECRET=test-secret-key-must-be-at-least-32-bytes-long-for-hs256",
+        "GOOGLE_CLIENT_ID=test-google",
+        "APPLE_CLIENT_ID=test-apple",
+        "DB_URL=jdbc:mysql://dummy:3306/dummy",
+        "DB_USERNAME=dummy",
+        "DB_PASSWORD=dummy",
+        "REDIS_HOST=dummy",
+        "REDIS_PASSWORD=dummy",
+        "SWAGGER_USERNAME=test-user",
+        "SWAGGER_PASSWORD=test-pass",
+        "management.server.port=8080",
+    ],
+)
+class SwaggerStagingBasicAuthTest(
+    @Autowired private val mockMvc: MockMvc,
+) : DescribeSpec({
+
+    describe("Basic Auth 설정으로 인해 credential 없는 요청은 실패한다") {
+        it("/swagger 401") {
+            val status = mockMvc.get("/swagger").andReturn().response.status
+            status shouldBe HttpStatus.UNAUTHORIZED.value()
+        }
+
+        it("/v3/api-docs 401") {
+            val status = mockMvc.get("/v3/api-docs").andReturn().response.status
+            status shouldBe HttpStatus.UNAUTHORIZED.value()
+        }
+
+        it("/swagger-ui/index.html 401") {
+            val status = mockMvc.get("/swagger-ui/index.html").andReturn().response.status
+            status shouldBe HttpStatus.UNAUTHORIZED.value()
+        }
+
+        it("응답에 WWW-Authenticate: Basic 헤더 포함") {
+            val header = mockMvc.get("/swagger").andReturn().response.getHeader("WWW-Authenticate")
+            header shouldContain "Basic"
+        }
+    }
+
+    describe("올바른 credential이 있는 요청은 성공한다") {
+        it("/v3/api-docs 200") {
+            val status = mockMvc.get("/v3/api-docs") {
+                header("Authorization", basicAuthHeader("test-user", "test-pass"))
+            }.andReturn().response.status
+
+            status shouldBe HttpStatus.OK.value()
+        }
+    }
+
+    describe("잘못된 credential이라면 요청이 실패한다") {
+        it("/v3/api-docs 401") {
+            val status = mockMvc.get("/v3/api-docs") {
+                header("Authorization", basicAuthHeader("test-user", "wrong-pass"))
+            }.andReturn().response.status
+
+            status shouldBe HttpStatus.UNAUTHORIZED.value()
+        }
+    }
+
+    describe("swagger chain 이 비-swagger 경로에 개입하지 않음") {
+        it("POST /api/v1/auth/social-login 응답에 WWW-Authenticate Basic 헤더 부재") {
+            val response = mockMvc.post("/api/v1/auth/social-login") {
+                contentType = org.springframework.http.MediaType.APPLICATION_JSON
+                content = "{}"
+            }.andReturn().response
+
+            val wwwAuth = response.getHeader("WWW-Authenticate")
+            (wwwAuth?.contains("Basic") == true) shouldBe false
+        }
+
+        it("/actuator/health 200 (management 포트 통합)") {
+            val status = mockMvc.get("/actuator/health").andReturn().response.status
+            status shouldBe HttpStatus.OK.value()
+        }
+    }
+})

--- a/src/test/kotlin/com/whatever/caro/common/config/PublicEndpointsOpenApiConsistencyTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/config/PublicEndpointsOpenApiConsistencyTest.kt
@@ -1,0 +1,69 @@
+package com.whatever.caro.common.config
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.auth.internal.config.PublicEndpoints
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.util.AntPathMatcher
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
+class PublicEndpointsOpenApiConsistencyTest(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val jsonMapper: JsonMapper,
+) : DescribeSpec({
+
+    fun fetchApiDocs(): JsonNode =
+        mockMvc.get("/v3/api-docs")
+            .andReturn().response.contentAsString
+            .let { jsonMapper.readTree(it) }
+
+    fun isEmptyArray(
+        node: JsonNode?,
+    ): Boolean = node != null && node.isArray && node.isEmpty
+
+    val antMatcher = AntPathMatcher()
+
+    describe("PublicEndpoints.AUTH ↔ OpenAPI security:[] 양방향 정합성") {
+
+        it("PublicEndpoints.AUTH 의 모든 경로는 security:[]로 직렬화된다 (@PublicApi 누락 확인)") {
+            val apiDocs = fetchApiDocs()
+
+            PublicEndpoints.AUTH.forEach { registeredPath ->
+                val pathNode = apiDocs.get("paths")?.get(registeredPath)
+                pathNode.shouldNotBeNull()
+
+                pathNode.properties().forEach { (method, operation) ->
+                    operation.get("security").shouldBeEmpty()
+                }
+            }
+        }
+
+        it("security:[]인 모든 경로는 PublicEndpoints.AUTH 에 매칭된다 (PATTERNS 등록 누락 확인)") {
+            val apiDocs = fetchApiDocs()
+            val pathsNode = apiDocs.get("paths")
+            pathsNode.shouldNotBeNull()
+
+            pathsNode.properties().forEach { (documentedPath, pathNode) ->
+                pathNode.properties().forEach { (method, operation) ->
+                    val security = operation.get("security") ?: return@forEach
+                    if (!isEmptyArray(security)) return@forEach
+
+                    PublicEndpoints.AUTH
+                        .firstOrNull { pattern -> antMatcher.match(pattern, documentedPath) }
+                        .shouldNotBeNull()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/whatever/caro/common/config/SwaggerDisabledInProdTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/config/SwaggerDisabledInProdTest.kt
@@ -1,0 +1,53 @@
+package com.whatever.caro.common.config
+
+import com.whatever.caro.TestcontainersConfiguration
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("prod")
+@Import(TestcontainersConfiguration::class)
+@TestPropertySource(
+    properties = [
+        "JWT_SECRET=test-secret-key-must-be-at-least-32-bytes-long-for-hs256",
+        "GOOGLE_CLIENT_ID=test-google-client-id",
+        "APPLE_CLIENT_ID=test-apple-client-id",
+        "DB_URL=jdbc:mysql://dummy:3306/dummy",
+        "DB_USERNAME=dummy",
+        "DB_PASSWORD=dummy",
+        "REDIS_HOST=dummy",
+        "REDIS_PASSWORD=dummy",
+    ],
+)
+class SwaggerDisabledInProdTest(
+    @Autowired private val mockMvc: MockMvc,
+) : DescribeSpec({
+
+    fun statusOf(
+        url: String,
+    ): Int = mockMvc.get(url).andReturn().response.status
+
+    describe("prod profile 에서 Swagger UI/api-docs 비활성화") {
+        it("/swagger 404") {
+            statusOf("/swagger") shouldBe HttpStatus.NOT_FOUND.value()
+        }
+
+        it("/swagger-ui/index.html 404") {
+            statusOf("/swagger-ui/index.html") shouldBe HttpStatus.NOT_FOUND.value()
+        }
+
+        it("/v3/api-docs 404") {
+            statusOf("/v3/api-docs") shouldBe HttpStatus.NOT_FOUND.value()
+        }
+    }
+})

--- a/src/test/kotlin/com/whatever/caro/common/config/SwaggerLocalAccessTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/config/SwaggerLocalAccessTest.kt
@@ -1,0 +1,40 @@
+package com.whatever.caro.common.config
+
+import com.whatever.caro.TestcontainersConfiguration
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+@Import(TestcontainersConfiguration::class)
+class SwaggerLocalAccessTest(
+    @Autowired private val mockMvc: MockMvc,
+) : DescribeSpec({
+
+    fun statusOf(
+        url: String,
+    ): Int = mockMvc.get(url).andReturn().response.status
+
+    describe("local 에서 Swagger HTTP 응답") {
+        it("/swagger → 3xx 리다이렉트") {
+            statusOf("/swagger") shouldBe HttpStatus.FOUND.value()
+        }
+
+        it("/swagger-ui/index.html → 200") {
+            statusOf("/swagger-ui/index.html") shouldBe HttpStatus.OK.value()
+        }
+
+        it("/v3/api-docs → 200") {
+            statusOf("/v3/api-docs") shouldBe HttpStatus.OK.value()
+        }
+    }
+})


### PR DESCRIPTION
## 📌 Related Issue
Closes #21 

## 📝 Changes
- Spring Boot 4.x 호환을 위해 `springdoc-openapi-starter-webmvc-ui:3.0.3` 추가
- OpenApiConfig` 에 Bearer JWT SecurityScheme 및 글로벌 SecurityRequirement 등록

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
- 인증이 필요 없는 api를 위해 `@PublicApi` 메타 어노테이션을 추가했습니다.(해당 어노테이션을 사용해도 PublicEndpoints에 등록은 해주어야합니다)
- 배포 시 SWAGGER_USERNAME, SWAGGER_PASSWORD 환경변수를 infisical에 추가로 넣어줘야합니다