### PR TITLE
[Refactor] Study 모듈 데이터 모델 정비

### DIFF
--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckPreset.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckPreset.kt
@@ -44,6 +44,9 @@ class DeckPreset(
 
     @Column(name = "leech_threshold", nullable = false)
     var leechThreshold: Int = 8,
+
+    @Column(name = "hard_badge_threshold", nullable = false)
+    val hardBadgeThreshold: Int = 3,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckPreset.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckPreset.kt
@@ -12,40 +12,40 @@ import java.math.BigDecimal
 @Entity
 @Table(name = "deck_presets")
 class DeckPreset(
-    @Column(name = "user_id", nullable = true)
+    @Column(name = "user_id", nullable = true, updatable = false)
     val userId: Long? = null,
 
-    @Column(nullable = false)
-    var name: String,
+    @Column(nullable = false, updatable = false)
+    val name: String,
 
-    @Column(name = "new_per_day", nullable = false)
-    var newPerDay: Int = 20,
+    @Column(name = "new_per_day", nullable = false, updatable = false)
+    val newPerDay: Int = 20,
 
-    @Column(name = "new_fair_interval", nullable = false)
-    var newFairInterval: Int = 1,
+    @Column(name = "new_fair_interval", nullable = false, updatable = false)
+    val newFairInterval: Int = 1,
 
-    @Column(name = "new_easy_interval", nullable = false)
-    var newEasyInterval: Int = 4,
+    @Column(name = "new_easy_interval", nullable = false, updatable = false)
+    val newEasyInterval: Int = 4,
 
-    @Column(name = "new_initial_ease_factor", nullable = false, precision = 3, scale = 2)
-    var newInitialEaseFactor: BigDecimal = BigDecimal("2.50"),
+    @Column(name = "new_initial_ease_factor", nullable = false, precision = 3, scale = 2, updatable = false)
+    val newInitialEaseFactor: BigDecimal = BigDecimal("2.50"),
 
-    @Column(name = "review_per_day", nullable = false)
-    var reviewPerDay: Int = 40,
+    @Column(name = "review_per_day", nullable = false, updatable = false)
+    val reviewPerDay: Int = 40,
 
-    @Column(name = "review_max_interval", nullable = false)
-    var reviewMaxInterval: Int = 36500,
+    @Column(name = "review_max_interval", nullable = false, updatable = false)
+    val reviewMaxInterval: Int = 36500,
 
-    @Column(name = "lapse_interval_multiplier", nullable = false, precision = 3, scale = 2)
-    var lapseIntervalMultiplier: BigDecimal = BigDecimal("0.40"),
+    @Column(name = "lapse_interval_multiplier", nullable = false, precision = 3, scale = 2, updatable = false)
+    val lapseIntervalMultiplier: BigDecimal = BigDecimal("0.40"),
 
-    @Column(name = "lapse_min_interval", nullable = false)
-    var lapseMinInterval: Int = 1,
+    @Column(name = "lapse_min_interval", nullable = false, updatable = false)
+    val lapseMinInterval: Int = 1,
 
-    @Column(name = "leech_threshold", nullable = false)
-    var leechThreshold: Int = 8,
+    @Column(name = "leech_threshold", nullable = false, updatable = false)
+    val leechThreshold: Int = 8,
 
-    @Column(name = "hard_badge_threshold", nullable = false)
+    @Column(name = "hard_badge_threshold", nullable = false, updatable = false)
     val hardBadgeThreshold: Int = 3,
 ) : BaseTimeEntity() {
     @Id

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningState.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningState.kt
@@ -47,6 +47,12 @@ class CardLearningState(
 
     @Column(name = "last_reviewed_at")
     var lastReviewedAt: Instant? = null,
+
+    @Column(name = "consecutive_again_count", nullable = false)
+    var consecutiveAgainCount: Int = 0,
+
+    @Column(name = "total_reviews", nullable = false)
+    var totalReviews: Int = 0,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -12,6 +12,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @Entity
 @Table(name = "study_sessions")
@@ -41,6 +43,18 @@ class StudySession(
 
     @Column(name = "review_cards_studied", nullable = false)
     var reviewCardsStudied: Int = 0,
+
+    @Column(name = "estimated_total", nullable = false)
+    var estimatedTotal: Int = 0,
+
+    @Column(name = "timezone", nullable = false, length = 64, updatable = false)
+    val timezone: ZoneId,
+
+    @Column(name = "day_cutoff_hour", nullable = false, updatable = false)
+    val dayCutoffHour: Int,
+
+    @Column(name = "session_date", nullable = false, updatable = false)
+    val sessionDate: LocalDate,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -55,6 +55,9 @@ class StudySession(
 
     @Column(name = "session_date", nullable = false, updatable = false)
     val sessionDate: LocalDate,
+
+    @Column(name = "deck_preset_id_snapshot", nullable = false, updatable = false)
+    val deckPresetIdSnapshot: Long,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/db/migration/card/V2__deck_preset_add_hard_threshold.sql
+++ b/src/main/resources/db/migration/card/V2__deck_preset_add_hard_threshold.sql
@@ -1,0 +1,3 @@
+ALTER TABLE deck_presets
+    ADD COLUMN hard_badge_threshold INT NOT NULL DEFAULT 3
+        COMMENT 'HARD 뱃지 판정을 위한 연속 AGAIN 평가 임계치';

--- a/src/main/resources/db/migration/study/V2__study_module_add_column.sql
+++ b/src/main/resources/db/migration/study/V2__study_module_add_column.sql
@@ -1,0 +1,25 @@
+ALTER TABLE study_sessions
+    ADD COLUMN estimated_total INT NOT NULL DEFAULT 0
+        COMMENT 'min(NEW 후보, new_per_day) + min(REVIEW 후보, review_per_day). 시작 시 stamp, 카드 삭제 이벤트 시 동적 감소',
+
+    ADD COLUMN timezone VARCHAR(64) NOT NULL DEFAULT 'UTC'
+        COMMENT 'IANA timezone (예: Asia/Seoul)',
+
+    ADD COLUMN day_cutoff_hour TINYINT NOT NULL DEFAULT 4
+        COMMENT '하루 시작 시각 (0~23)',
+
+    ADD COLUMN session_date DATE NOT NULL DEFAULT '2026-05-03'
+        COMMENT '사용자 timezone과 day_cutoff_hour를 적용한 실제 학습일',
+
+    ADD CONSTRAINT chk_session_estimated_total CHECK (estimated_total >= 0),
+    ADD CONSTRAINT chk_session_cutoff_hour CHECK (day_cutoff_hour BETWEEN 0 AND 23);
+
+ALTER TABLE card_learning_states
+    ADD COLUMN consecutive_again_count INT NOT NULL DEFAULT 0
+        COMMENT '카드의 연속 AGAIN 횟수. EASY/FAIR 평가 시 0으로 리셋.',
+
+    ADD COLUMN total_reviews INT NOT NULL DEFAULT 0
+        COMMENT '누적 평가 횟수.',
+
+    ADD CONSTRAINT chk_ls_consecutive_again_count CHECK (consecutive_again_count >= 0),
+    ADD CONSTRAINT chk_ls_total_reviews CHECK (total_reviews >= 0);

--- a/src/main/resources/db/migration/study/V3__study_session_add_deck_preset_snapshot.sql
+++ b/src/main/resources/db/migration/study/V3__study_session_add_deck_preset_snapshot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE study_sessions
+    ADD COLUMN deck_preset_id_snapshot BIGINT NOT NULL;


### PR DESCRIPTION
## 📌 Related Issue
Closes #29 

## 📝 Changes
### 1. study_sessions: 4개 컬럼 추가 (study/V2)

- **estimated_total** `INT NOT NULL DEFAULT 0`
세션 시작 시 `min(NEW 후보, new_per_day) + min(REVIEW 후보, review_per_day)` 계산하여 저장.
일일학습 진행률(평가 수 / estimated_total)의 분모 역할.
카드 삭제 이벤트 발생 시에만 동적 감소.

- **timezone** `VARCHAR(64) NOT NULL DEFAULT 'UTC'`
세션 시작 시점의 IANA timezone(예: `Asia/Seoul`)을 저장.

- **day_cutoff_hour** `TINYINT NOT NULL DEFAULT 4`
세션의 끝을 판별하기 위한 "하루의 시작" 시각 (default 4 AM).

- **session_date** `DATE NOT NULL`
사용자의 timezone + day_cutoff_hour를 적용한 실제 학습일.
재학습 감지와, 학습 세션 날짜가 단조적으로 증가할 수 있도록 보장하기 위해 사용.

### 2. card_learning_states: 2개 컬럼 추가 (study/V2)

- **consecutive_again_count** `INT NOT NULL DEFAULT 0`
REVIEW 카드의 연속 AGAIN 횟수. EASY/FAIR 평가 시 0 리셋.
카드 리스트 응답의 HARD 뱃지 판정용.

- **total_reviews** `INT NOT NULL DEFAULT 0`
카드별 누적 평가 횟수.

### 3. deck_presets: hard_badge_threshold 추가 (card/V2)

- **hard_badge_threshold** `INT NOT NULL DEFAULT 3`
카드 리스트의 HARD 뱃지 판정 임계치 (`연속 AGAIN 횟수 >= 이 값`이라면 HARD).

### 4. study_sessions: deck_preset_id_snapshot 추가 (study/V3)

- **deck_preset_id_snapshot** `BIGINT NOT NULL`
세션 시작 시점의 deck preset id를 snapshot. SM-2 계산은 항상 이 snapshot id로 진행.
학습 진행 중 사용자가 deck preset 변경할 경우, 새 deck_presets row가 INSERT되고 Deck.deck_preset_id가 새 id를 가리키게 됨.
진행 중인 학습세션은 옛 snapshot id를 그대로 참조하므로 일관된 평가 기준 유지 가능.

### 5. DeckPreset 엔티티: Append-Only 정책

`DeckPreset`의 학습 파라미터 12개를 모두 `val` + `@Column(updatable = false)`로 전환.
- preset 변경 시 row UPDATE 금지하며 대신, 새 row INSERT
- 기존 row는 학습 세션이 참조 중이므로 영구 보존


## ✅ Checklist
- [x] Flyway 마이그레이션 확인
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
- 인덱스는 개발하며 쿼리 패턴을 보고 추가해야함