### PR TITLE
[Feat] study 모듈 구현 전 공용으로 사용 가능한 멱등성 요청 구현

### DIFF
--- a/src/main/kotlin/com/whatever/caro/CaroApplication.kt
+++ b/src/main/kotlin/com/whatever/caro/CaroApplication.kt
@@ -2,11 +2,13 @@ package com.whatever.caro
 
 import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import java.time.ZoneId
 import java.util.TimeZone
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class CaroApplication {
     @PostConstruct
     fun init() {

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
@@ -5,7 +5,10 @@ import com.whatever.caro.auth.internal.filter.JwtAuthenticationFilter
 import com.whatever.caro.auth.internal.filter.JwtExceptionFilter
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.common.response.ErrorCodeSpec
+import com.whatever.caro.common.web.filter.RequestResponseCachingFilter
+import jakarta.servlet.Filter
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
@@ -24,6 +27,7 @@ import tools.jackson.databind.json.JsonMapper
 @EnableWebSecurity
 @EnableMethodSecurity
 class SecurityConfig(
+    private val requestResponseCachingFilter: RequestResponseCachingFilter,
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val jwtExceptionFilter: JwtExceptionFilter,
     private val jsonMapper: JsonMapper,
@@ -55,6 +59,7 @@ class SecurityConfig(
 
             addFilterBefore<UsernamePasswordAuthenticationFilter>(jwtExceptionFilter)
             addFilterBefore<UsernamePasswordAuthenticationFilter>(jwtAuthenticationFilter)
+            addFilterAfter<JwtAuthenticationFilter>(requestResponseCachingFilter)
 
             exceptionHandling {
                 authenticationEntryPoint = customAuthenticationEntryPoint()
@@ -83,4 +88,26 @@ class SecurityConfig(
         response.characterEncoding = "UTF-8"
         jsonMapper.writeValue(response.writer, ApiResponse.fail(errorCode))
     }
+}
+
+@Configuration
+class SecurityFilterRegistrationConfig {
+    @Bean
+    fun jwtExceptionFilterRegistration(
+        filter: JwtExceptionFilter,
+    ): FilterRegistrationBean<JwtExceptionFilter> = disableFilterRegistration(filter)
+
+    @Bean
+    fun jwtAuthenticationFilterRegistration(
+        filter: JwtAuthenticationFilter,
+    ): FilterRegistrationBean<JwtAuthenticationFilter> = disableFilterRegistration(filter)
+
+    @Bean
+    fun requestResponseCachingFilterRegistration(
+        filter: RequestResponseCachingFilter,
+    ): FilterRegistrationBean<RequestResponseCachingFilter> = disableFilterRegistration(filter)
+
+    private fun <T : Filter> disableFilterRegistration(
+        filter: T,
+    ): FilterRegistrationBean<T> = FilterRegistrationBean(filter).apply { isEnabled = false }
 }

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
@@ -6,7 +6,6 @@ import com.whatever.caro.auth.internal.filter.JwtExceptionFilter
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.common.response.ErrorCodeSpec
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
@@ -24,7 +23,6 @@ import tools.jackson.databind.json.JsonMapper
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-@EnableConfigurationProperties(JwtProperties::class, OAuth2Properties::class)
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val jwtExceptionFilter: JwtExceptionFilter,

--- a/src/main/kotlin/com/whatever/caro/auth/internal/token/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/token/RefreshTokenRepository.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Repository
 import java.time.Duration
 
@@ -113,9 +114,8 @@ class RefreshTokenRepository(
         private const val KEY_PREFIX = "refresh"
         private const val TOKEN_PAIR_KEY_PREFIX = "token_pair"
 
-        private val SAVE_SCRIPT = DefaultRedisScript<Boolean>().apply {
-            setScriptText(
-                """
+        private val SAVE_SCRIPT = RedisScript.of(
+            """
                 -- KEYS[1] = forward key (refresh:userId:deviceId)
                 -- KEYS[2] = token_pair key (token_pair:refreshToken)
                 -- ARGV[1] = refreshToken (forward value)
@@ -127,17 +127,15 @@ class RefreshTokenRepository(
                     redis.call('DEL', '${TOKEN_PAIR_KEY_PREFIX}:' .. previous)
                 end
 
-                redis.call('SETEX', KEYS[1], ARGV[3], ARGV[1])
-                redis.call('SETEX', KEYS[2], ARGV[3], ARGV[2])
+                redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+                redis.call('SET', KEYS[2], ARGV[2], 'EX', ARGV[3])
                 return true
-                """.trimIndent(),
-            )
-            resultType = Boolean::class.java
-        }
+            """.trimIndent(),
+            Boolean::class.java,
+        )
 
-        private val CONSUME_SCRIPT = DefaultRedisScript<String>().apply {
-            setScriptText(
-                """
+        private val CONSUME_SCRIPT = RedisScript.of(
+            """
                 -- KEYS[1] = token_pair key (token_pair:refreshToken)
                 -- ARGV[1] = userId
                 -- ARGV[2] = deviceId
@@ -158,9 +156,8 @@ class RefreshTokenRepository(
                 else
                     return nil
                 end
-                """.trimIndent(),
-            )
-            resultType = String::class.java
-        }
+            """.trimIndent(),
+            String::class.java,
+        )
     }
 }

--- a/src/main/kotlin/com/whatever/caro/common/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/WebMvcConfig.kt
@@ -1,0 +1,17 @@
+package com.whatever.caro.common.config
+
+import com.whatever.caro.common.web.idempotency.IdempotencyInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val idempotencyInterceptor: IdempotencyInterceptor,
+) : WebMvcConfigurer {
+    override fun addInterceptors(
+        registry: InterceptorRegistry,
+    ) {
+        registry.addInterceptor(idempotencyInterceptor)
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -62,6 +63,22 @@ class GlobalExceptionHandler(
                 ApiResponse.fail(
                     CommonErrorCode.INVALID_REQUEST,
                     resolveMessage(CommonErrorCode.INVALID_REQUEST, null, locale),
+                ),
+            )
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingHeader(
+        e: MissingRequestHeaderException,
+        locale: Locale,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        logger.warn { "Missing header: ${e.headerName}" }
+        return ResponseEntity
+            .badRequest()
+            .body(
+                ApiResponse.fail(
+                    CommonErrorCode.MISSING_HEADER,
+                    resolveMessage(CommonErrorCode.MISSING_HEADER, arrayOf(e.headerName), locale),
                 ),
             )
     }

--- a/src/main/kotlin/com/whatever/caro/common/response/CommonErrorCode.kt
+++ b/src/main/kotlin/com/whatever/caro/common/response/CommonErrorCode.kt
@@ -14,5 +14,24 @@ enum class CommonErrorCode(
     METHOD_NOT_ALLOWED("C004", HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다", "error.common.method_not_allowed"),
     MISSING_PARAMETER("C005", HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다", "error.common.missing_parameter"),
     TYPE_MISMATCH("C006", HttpStatus.BAD_REQUEST, "파라미터 타입이 올바르지 않습니다", "error.common.type_mismatch"),
+    MISSING_HEADER("C007", HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다", "error.common.missing_header"),
+    INVALID_IDEMPOTENCY_KEY(
+        "C008",
+        HttpStatus.BAD_REQUEST,
+        "유효하지 않은 Idempotency-Key 형식입니다",
+        "error.common.invalid_idempotency_key",
+    ),
+    IDEMPOTENCY_KEY_CONFLICT(
+        "C009",
+        HttpStatus.CONFLICT,
+        "동일한 Idempotency-Key로 다른 요청이 처리되었습니다",
+        "error.common.idempotency_key_conflict",
+    ),
+    IDEMPOTENCY_REQUEST_IN_PROGRESS(
+        "C010",
+        HttpStatus.CONFLICT,
+        "이전 요청이 처리 중입니다. 잠시 후 다시 시도해주세요",
+        "error.common.idempotency_request_in_progress",
+    ),
     INTERNAL_ERROR("C999", HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다", "error.common.internal_error"),
 }

--- a/src/main/kotlin/com/whatever/caro/common/web/filter/CachedBodyHttpServletRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/filter/CachedBodyHttpServletRequest.kt
@@ -1,0 +1,40 @@
+package com.whatever.caro.common.web.filter
+
+import jakarta.servlet.ReadListener
+import jakarta.servlet.ServletInputStream
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import org.springframework.util.StreamUtils
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.InputStreamReader
+
+class CachedBodyHttpServletRequest(
+    request: HttpServletRequest,
+) : HttpServletRequestWrapper(request) {
+    // 원본 request의 input stream은 해당 시점에서 소멸
+    private val cachedBody: ByteArray = StreamUtils.copyToByteArray(request.inputStream)
+
+    override fun getInputStream(): ServletInputStream = CachedServletInputStream(cachedBody)
+
+    override fun getReader(): BufferedReader =
+        BufferedReader(InputStreamReader(ByteArrayInputStream(cachedBody), Charsets.UTF_8))
+
+    fun contentAsByteArray(): ByteArray = cachedBody.copyOf()
+}
+
+private class CachedServletInputStream(
+    cachedBody: ByteArray,
+) : ServletInputStream() {
+    private val inputStream = ByteArrayInputStream(cachedBody)
+
+    override fun read(): Int = inputStream.read()
+
+    override fun isFinished(): Boolean = inputStream.available() == 0
+
+    override fun isReady(): Boolean = true
+
+    override fun setReadListener(
+        listener: ReadListener?,
+    ): Unit = throw UnsupportedOperationException()
+}

--- a/src/main/kotlin/com/whatever/caro/common/web/filter/RequestResponseCachingFilter.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/filter/RequestResponseCachingFilter.kt
@@ -1,0 +1,26 @@
+package com.whatever.caro.common.web.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingResponseWrapper
+
+@Component
+class RequestResponseCachingFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val cachedRequest = CachedBodyHttpServletRequest(request)
+        val cachedResponse = ContentCachingResponseWrapper(response)
+
+        try {
+            filterChain.doFilter(cachedRequest, cachedResponse)
+        } finally {
+            cachedResponse.copyBodyToResponse()
+        }
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
@@ -97,14 +97,16 @@ class IdempotencyInterceptor(
             return
         }
 
-        var isSaved = false
-        try {
-            val response = WebUtils.getNativeResponse(
-                response,
-                ContentCachingResponseWrapper::class.java,
-            ) ?: return
-            val body = response.contentAsByteArray.toString(Charsets.UTF_8)
+        val response = WebUtils.getNativeResponse(
+            response,
+            ContentCachingResponseWrapper::class.java,
+        ) ?: run {
+            deleteProcessingOnCacheSkip(redisKey)
+            return
+        }
 
+        try {
+            val body = response.contentAsByteArray.toString(Charsets.UTF_8)
             repository.saveResponse(
                 redisKey,
                 hash,
@@ -113,13 +115,16 @@ class IdempotencyInterceptor(
                 body,
                 properties.responseTtl,
             )
-            isSaved = true
-        } finally {
-            if (!isSaved) { // 캐싱 과정에서 예외 발생 시 processing key 제거
-                runCatching { repository.deleteIdempotencyProcessing(redisKey) }
-                logger.warn { "Idempotency response cache skipped. Processing key released. key: $redisKey" }
-            }
+        } catch (e: Exception) {
+            deleteProcessingOnCacheSkip(redisKey)
         }
+    }
+
+    private fun deleteProcessingOnCacheSkip(
+        redisKey: String,
+    ) {
+        runCatching { repository.deleteIdempotencyProcessing(redisKey) }
+        logger.warn { "Idempotency response cache skipped. Processing key released. key: $redisKey" }
     }
 
     private fun isValidKey(

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
@@ -1,0 +1,157 @@
+package com.whatever.caro.common.web.idempotency
+
+import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.common.exception.BusinessException
+import com.whatever.caro.common.response.CommonErrorCode.IDEMPOTENCY_KEY_CONFLICT
+import com.whatever.caro.common.response.CommonErrorCode.IDEMPOTENCY_REQUEST_IN_PROGRESS
+import com.whatever.caro.common.response.CommonErrorCode.INVALID_IDEMPOTENCY_KEY
+import com.whatever.caro.common.response.CommonErrorCode.MISSING_HEADER
+import com.whatever.caro.common.web.filter.CachedBodyHttpServletRequest
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.util.ContentCachingResponseWrapper
+import org.springframework.web.util.WebUtils
+import java.security.MessageDigest
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class IdempotencyInterceptor(
+    private val repository: IdempotencyRepository,
+    private val properties: IdempotencyProperties,
+) : HandlerInterceptor {
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        val handlerMethod = handler as? HandlerMethod ?: return true
+        val annotation = handlerMethod.getMethodAnnotation(Idempotent::class.java) ?: return true
+
+        val key = request.getHeader("Idempotency-Key")
+            ?: throw BusinessException(MISSING_HEADER, arrayOf("Idempotency-Key"))
+        if (!isValidKey(key)) {
+            throw BusinessException(INVALID_IDEMPOTENCY_KEY)
+        }
+
+        val userId = SecurityUtil.currentUser().userId
+        val redisKey = "idempotency:$userId:$key"
+
+        val cachedRequest = WebUtils.getNativeRequest(request, CachedBodyHttpServletRequest::class.java)
+            ?: throw IllegalStateException(
+                "RequestResponseCachingFilter must be registered before IdempotencyInterceptor",
+            )
+
+        val path = cachedRequest.requestURI.trimEnd('/').ifEmpty { "/" }
+        val query = cachedRequest.queryString ?: ""
+        val newHash = computeHash(
+            cachedRequest.method,
+            "$path?$query",
+            cachedRequest.contentAsByteArray(),
+        )
+
+        repository.getCachedResponse(redisKey)?.let { cachedEntry ->
+            if (cachedEntry.hash != newHash) {
+                throw BusinessException(IDEMPOTENCY_KEY_CONFLICT)
+            }
+            response.status = cachedEntry.statusCode
+            response.contentType = cachedEntry.contentType
+            response.characterEncoding = Charsets.UTF_8.name()
+            response.writer.write(cachedEntry.body)
+
+            return false
+        }
+
+        if (!repository.acquireIdempotencyProcessing(redisKey, properties.processingTtl)) { // 이미 진행중일 경우
+            throw BusinessException(IDEMPOTENCY_REQUEST_IN_PROGRESS)
+        }
+
+        cachedRequest.setAttribute(ATTR_REDIS_KEY, redisKey)
+        cachedRequest.setAttribute(ATTR_HASH, newHash)
+        cachedRequest.setAttribute(ATTR_CACHE_INTERNAL_ERROR_RESPONSE, annotation.cacheInternalErrorResponse)
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        val redisKey = request.getAttribute(ATTR_REDIS_KEY) as? String ?: return
+        val hash = request.getAttribute(ATTR_HASH) as? String ?: return
+        val cacheInternalErrorResponse = request.getAttribute(ATTR_CACHE_INTERNAL_ERROR_RESPONSE) as? Boolean ?: false
+
+        val isInternalError = response.status in 500..599 || ex != null
+        if (!cacheInternalErrorResponse && isInternalError) {
+            runCatching { repository.deleteIdempotencyProcessing(redisKey) }
+            logger.warn {
+                "Bypassing response cache: status=${response.status}, ex=${ex?.javaClass?.simpleName}, key=$redisKey"
+            }
+            return
+        }
+
+        var isSaved = false
+        try {
+            val response = WebUtils.getNativeResponse(
+                response,
+                ContentCachingResponseWrapper::class.java,
+            ) ?: return
+            val body = response.contentAsByteArray.toString(Charsets.UTF_8)
+
+            repository.saveResponse(
+                redisKey,
+                hash,
+                response.status,
+                response.contentType ?: MediaType.APPLICATION_JSON_VALUE,
+                body,
+                properties.responseTtl,
+            )
+            isSaved = true
+        } finally {
+            if (!isSaved) { // 캐싱 과정에서 예외 발생 시 processing key 제거
+                runCatching { repository.deleteIdempotencyProcessing(redisKey) }
+                logger.warn { "Idempotency response cache skipped. Processing key released. key: $redisKey" }
+            }
+        }
+    }
+
+    private fun isValidKey(
+        key: String,
+    ): Boolean {
+        try {
+            UUID.fromString(key)
+            return true
+        } catch (e: IllegalArgumentException) {
+            return false
+        }
+    }
+
+    private fun computeHash(
+        method: String,
+        path: String,
+        body: ByteArray,
+    ): String {
+        val md = MessageDigest.getInstance("SHA-256").apply {
+            update(method.toByteArray())
+            update(ASCII_US)
+            update(path.toByteArray())
+            update(ASCII_US)
+            update(body)
+        }
+        return md.digest().toHexString()
+    }
+
+    companion object {
+        private const val ATTR_REDIS_KEY = "caro.idempotency.redisKey"
+        private const val ATTR_HASH = "caro.idempotency.hash"
+        private const val ATTR_CACHE_INTERNAL_ERROR_RESPONSE = "caro.idempotency.cacheInternalErrorResponse"
+        private const val ASCII_US: Byte = 0x1F
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
@@ -124,14 +124,13 @@ class IdempotencyInterceptor(
 
     private fun isValidKey(
         key: String,
-    ): Boolean {
-        return try {
+    ): Boolean =
+        try {
             UUID.fromString(key)
             true
         } catch (e: IllegalArgumentException) {
             false
         }
-    }
 
     private fun computeHash(
         method: String,

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptor.kt
@@ -49,7 +49,7 @@ class IdempotencyInterceptor(
             )
 
         val path = cachedRequest.requestURI.trimEnd('/').ifEmpty { "/" }
-        val query = cachedRequest.queryString ?: ""
+        val query = cachedRequest.queryString.orEmpty()
         val newHash = computeHash(
             cachedRequest.method,
             "$path?$query",
@@ -125,11 +125,11 @@ class IdempotencyInterceptor(
     private fun isValidKey(
         key: String,
     ): Boolean {
-        try {
+        return try {
             UUID.fromString(key)
-            return true
+            true
         } catch (e: IllegalArgumentException) {
-            return false
+            false
         }
     }
 

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyProperties.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyProperties.kt
@@ -1,0 +1,27 @@
+package com.whatever.caro.common.web.idempotency
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+private val logger = KotlinLogging.logger {}
+
+@ConfigurationProperties(prefix = "app.idempotency")
+data class IdempotencyProperties(
+    val responseTtl: Duration,
+    val processingTtl: Duration,
+) {
+    @PostConstruct
+    fun validate() {
+        require(!responseTtl.isNegative && !responseTtl.isZero) {
+            "app.idempotency.response-ttl must be positive: $responseTtl"
+        }
+        require(!processingTtl.isNegative && !processingTtl.isZero) {
+            "app.idempotency.processing-ttl must be positive: $processingTtl"
+        }
+        logger.info {
+            "IdempotencyProperties loaded: responseTtl=$responseTtl, processingTtl=$processingTtl"
+        }
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyProperties.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyProperties.kt
@@ -14,10 +14,10 @@ data class IdempotencyProperties(
 ) {
     @PostConstruct
     fun validate() {
-        require(!responseTtl.isNegative && !responseTtl.isZero) {
+        require(responseTtl.isPositive && !responseTtl.isZero) {
             "app.idempotency.response-ttl must be positive: $responseTtl"
         }
-        require(!processingTtl.isNegative && !processingTtl.isZero) {
+        require(processingTtl.isPositive && !processingTtl.isZero) {
             "app.idempotency.processing-ttl must be positive: $processingTtl"
         }
         logger.info {

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyRepository.kt
@@ -1,0 +1,89 @@
+package com.whatever.caro.common.web.idempotency
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import org.springframework.stereotype.Repository
+import tools.jackson.databind.json.JsonMapper
+import java.time.Duration
+
+@Repository
+class IdempotencyRepository(
+    private val redisTemplate: StringRedisTemplate,
+    private val jsonMapper: JsonMapper,
+) {
+    fun acquireIdempotencyProcessing(
+        key: String,
+        expiresIn: Duration,
+    ): Boolean =
+        redisTemplate.opsForValue().setIfAbsent(
+            "$key:processing",
+            "1",
+            expiresIn,
+        ) == true
+
+    fun saveResponse(
+        key: String,
+        hash: String,
+        statusCode: Int,
+        contentType: String,
+        body: String,
+        expiresIn: Duration,
+    ) {
+        val payload = IdempotencyEntry(
+            hash = hash,
+            statusCode = statusCode,
+            contentType = contentType,
+            body = body,
+        )
+
+        val keys = listOf(
+            key,
+            "$key:processing",
+        )
+        val args = listOf(
+            jsonMapper.writeValueAsString(payload),
+            expiresIn.seconds.toString(),
+        )
+        redisTemplate.execute(
+            SCRIPT,
+            keys,
+            *args.toTypedArray(),
+        )
+    }
+
+    fun getCachedResponse(
+        key: String,
+    ): IdempotencyEntry? {
+        val payload = redisTemplate.opsForValue().get(key) ?: return null
+        return jsonMapper.readValue(payload, IdempotencyEntry::class.java)
+    }
+
+    fun deleteIdempotencyProcessing(
+        key: String,
+    ) {
+        redisTemplate.delete("$key:processing")
+    }
+
+    companion object {
+        private val SCRIPT = RedisScript.of(
+            """
+                -- KEYS[1] = redis key
+                -- KEYS[2] = processing key
+                -- ARGV[1] = idempotency entry json string
+                -- ARGV[2] = expiry seconds
+
+                redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+                redis.call('DEL', KEYS[2])
+                return 1
+            """.trimIndent(),
+            Long::class.java,
+        )
+    }
+}
+
+data class IdempotencyEntry(
+    val hash: String,
+    val statusCode: Int,
+    val contentType: String,
+    val body: String,
+)

--- a/src/main/kotlin/com/whatever/caro/common/web/idempotency/Idempotent.kt
+++ b/src/main/kotlin/com/whatever/caro/common/web/idempotency/Idempotent.kt
@@ -1,0 +1,12 @@
+package com.whatever.caro.common.web.idempotency
+
+/**
+ * Idempotency 보장이 필요한 endpoint에 사용
+ * 해당 Annotation이 사용된 endpoint에는 다음이 강제되어야함:
+ *   - Idempotency-Key 헤더 (UUID v4 or ULID)
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Idempotent(
+    val cacheInternalErrorResponse: Boolean = false,
+)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,9 @@ app:
     secret: ${JWT_SECRET}
     access-token-expires-in: 30m
     refresh-token-expires-in: 14d
+  idempotency:
+    response-ttl: 24h
+    processing-ttl: 30s
   oauth2:
     google:
       client-id: ${GOOGLE_CLIENT_ID}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -5,6 +5,10 @@ error.common.not_found=Resource not found
 error.common.method_not_allowed=HTTP method not supported
 error.common.missing_parameter=Required parameter is missing: {0}
 error.common.type_mismatch=Invalid parameter type: {0}
+error.common.missing_header=Required header is missing: {0}
+error.common.invalid_idempotency_key=Invalid Idempotency-Key format
+error.common.idempotency_key_conflict=Idempotency-Key already used with a different request
+error.common.idempotency_request_in_progress=A previous request is still being processed
 error.common.internal_error=An unexpected error occurred
 # Auth
 error.auth.unauthorized=Authentication required

--- a/src/main/resources/messages_ko.properties
+++ b/src/main/resources/messages_ko.properties
@@ -5,6 +5,10 @@ error.common.not_found=요청한 리소스를 찾을 수 없습니다
 error.common.method_not_allowed=지원하지 않는 HTTP 메서드입니다
 error.common.missing_parameter=필수 파라미터가 누락되었습니다: {0}
 error.common.type_mismatch=파라미터 타입이 올바르지 않습니다: {0}
+error.common.missing_header=필수 헤더가 누락되었습니다: {0}
+error.common.invalid_idempotency_key=유효하지 않은 Idempotency-Key 형식입니다
+error.common.idempotency_key_conflict=동일한 Idempotency-Key로 다른 요청이 처리되었습니다
+error.common.idempotency_request_in_progress=이전 요청이 처리 중입니다. 잠시 후 다시 시도해주세요
 error.common.internal_error=내부 서버 오류가 발생했습니다
 # Auth
 error.auth.unauthorized=인증이 필요합니다

--- a/src/test/kotlin/com/whatever/caro/common/web/filter/CachedBodyHttpServletRequestUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/web/filter/CachedBodyHttpServletRequestUnitTest.kt
@@ -1,0 +1,75 @@
+package com.whatever.caro.common.web.filter
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+import org.springframework.mock.web.MockHttpServletRequest
+
+class CachedBodyHttpServletRequestUnitTest :
+    DescribeSpec({
+
+        describe("contentAsByteArray()") {
+            it("매 호출마다 원본 body byte와 동일한 복사본을 반환한다") {
+                val body = "hello world".toByteArray()
+                val mock = MockHttpServletRequest().apply { setContent(body) }
+                val req = CachedBodyHttpServletRequest(mock)
+
+                val body1 = req.contentAsByteArray()
+                val body2 = req.contentAsByteArray()
+
+                body1 shouldBe body
+                body2 shouldBe body
+                body1 shouldNotBeSameInstanceAs body2
+
+                body1[0] = 0xFF.toByte() // 임의로 body 변경
+                req.contentAsByteArray() shouldBe body // 새로 호출해도 원본 reference는 변경되지 않음
+            }
+        }
+
+        describe("getInputStream()") {
+            it("inputStream을 N회 호출해도 매번 읽을 수 있는 body를 반환한다") {
+                val body = "hello world".toByteArray()
+                val mock = MockHttpServletRequest().apply { setContent(body) }
+                val req = CachedBodyHttpServletRequest(mock)
+
+                repeat(3) {
+                    req.inputStream.readBytes() shouldBe body
+                }
+            }
+        }
+
+        describe("getReader()") {
+            it("reader를 N회 호출해도 매번 동일한 body를 디코드한다") {
+                val text = "hello world"
+                val body = text.toByteArray()
+                val mock = MockHttpServletRequest().apply { setContent(body) }
+                val req = CachedBodyHttpServletRequest(mock)
+
+                repeat(2) {
+                    req.reader.readText() shouldBe text
+                }
+                req.inputStream.readBytes() shouldBe body // reader 호출 후에도 inputStream 호출 가능
+            }
+        }
+
+        describe("cachedBody에 대한 일관성 확인") {
+            it("body에 대해 inputStream/contentAsByteArray/reader가 동일") {
+                val body = "안녕 world 🚀".toByteArray()
+                val mock = MockHttpServletRequest().apply { setContent(body) }
+                val req = CachedBodyHttpServletRequest(mock)
+
+                req.contentAsByteArray() shouldBe body
+                req.inputStream.readBytes() shouldBe body
+                req.reader.readText().toByteArray() shouldBe body
+            }
+
+            it("empty body에 대해 inputStream/contentAsByteArray/reader 모두 empty를 반환한다") {
+                val mock = MockHttpServletRequest().apply { setContent(ByteArray(0)) }
+                val req = CachedBodyHttpServletRequest(mock)
+
+                req.contentAsByteArray() shouldBe ByteArray(0)
+                req.inputStream.readBytes() shouldBe ByteArray(0)
+                req.reader.readText() shouldBe ""
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptorUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptorUnitTest.kt
@@ -459,7 +459,7 @@ class IdempotencyInterceptorUnitTest :
             }
 
             context("saveResponse에서 예외가 발생할 때") {
-                it("응답을 캐싱하지 않으며 processing 마커를 제거한다") {
+                it("응답을 캐싱하지 않고 processing 마커를 제거하며 예외는 삼켜진다") {
                     val request = requestWith()
                     val wrapped = wrappedResponseWith()
 
@@ -467,9 +467,7 @@ class IdempotencyInterceptorUnitTest :
                         idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any())
                     } throws RuntimeException("redis down")
 
-                    shouldThrow<RuntimeException> {
-                        interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
-                    }
+                    interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
 
                     verify { idempotencyRepository.deleteIdempotencyProcessing(defaultRedisKey) }
                 }

--- a/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptorUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyInterceptorUnitTest.kt
@@ -1,0 +1,478 @@
+package com.whatever.caro.common.web.idempotency
+
+import com.whatever.caro.auth.AuthUser
+import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.common.exception.BusinessException
+import com.whatever.caro.common.response.CommonErrorCode.IDEMPOTENCY_KEY_CONFLICT
+import com.whatever.caro.common.response.CommonErrorCode.IDEMPOTENCY_REQUEST_IN_PROGRESS
+import com.whatever.caro.common.response.CommonErrorCode.INVALID_IDEMPOTENCY_KEY
+import com.whatever.caro.common.response.CommonErrorCode.MISSING_HEADER
+import com.whatever.caro.common.web.filter.CachedBodyHttpServletRequest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainOnly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.slf4j.MDC
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.time.Duration
+import java.util.UUID
+
+class IdempotencyInterceptorUnitTest :
+    DescribeSpec({
+
+        val idempotencyRepository = mockk<IdempotencyRepository>(relaxUnitFun = true)
+        val properties = IdempotencyProperties(
+            responseTtl = Duration.ofHours(24),
+            processingTtl = Duration.ofSeconds(30),
+        )
+        val interceptor = IdempotencyInterceptor(idempotencyRepository, properties)
+
+        mockkObject(SecurityUtil)
+
+        afterSpec {
+            unmockkObject(SecurityUtil)
+        }
+
+        afterEach {
+            clearAllMocks(answers = false)
+            SecurityContextHolder.clearContext()
+            MDC.clear()
+        }
+
+        fun setupSecurityContext(
+            userId: Long = 1L,
+        ) {
+            val authUser = AuthUser(
+                userId = userId,
+                jti = "test-jti",
+                status = "ACTIVE",
+            )
+            val auth = UsernamePasswordAuthenticationToken(authUser, null, emptyList())
+            SecurityContextHolder.getContext().authentication = auth
+            every { SecurityUtil.currentUser() } returns authUser
+        }
+
+        fun cachedRequest(
+            method: String = "POST",
+            uri: String = "/api/v1/test",
+            query: String? = null,
+            body: ByteArray = ByteArray(0),
+            idempotencyKey: String? = UUID.randomUUID().toString(),
+        ): CachedBodyHttpServletRequest {
+            val mockHttpServletRequest = MockHttpServletRequest(method, uri).apply {
+                queryString = query
+                setContent(body)
+                idempotencyKey?.let { addHeader("Idempotency-Key", it) }
+            }
+            return CachedBodyHttpServletRequest(mockHttpServletRequest)
+        }
+
+        fun wrappedResponse(): Pair<MockHttpServletResponse, ContentCachingResponseWrapper> {
+            val mock = MockHttpServletResponse()
+            val wrapped = ContentCachingResponseWrapper(mock)
+            return mock to wrapped
+        }
+
+        fun handlerMethod(
+            cacheInternalErrorResponse: Boolean = false,
+        ): HandlerMethod {
+            val handler = mockk<HandlerMethod>()
+            val annotation = mockk<Idempotent>()
+            every { annotation.cacheInternalErrorResponse } returns cacheInternalErrorResponse
+            every { handler.getMethodAnnotation(Idempotent::class.java) } returns annotation
+            return handler
+        }
+
+        fun primeHash(
+            request: CachedBodyHttpServletRequest,
+            handler: HandlerMethod,
+        ): String {
+            every { idempotencyRepository.getCachedResponse(any()) } returns null
+            every { idempotencyRepository.acquireIdempotencyProcessing(any(), any()) } returns true
+            interceptor.preHandle(request, MockHttpServletResponse(), handler)
+            return request.getAttribute("caro.idempotency.hash") as String
+        }
+
+        describe("preHandle()") {
+            context("Idempotency-Key 헤더가 없을 때") {
+                it("BusinessException(MISSING_HEADER)을 던지고, args에 헤더 이름이 담긴다") {
+                    setupSecurityContext()
+                    val request = cachedRequest(idempotencyKey = null)
+                    val response = MockHttpServletResponse()
+                    val handler = handlerMethod()
+
+                    val exception = shouldThrow<BusinessException> {
+                        interceptor.preHandle(request, response, handler)
+                    }
+                    exception.errorCode shouldBe MISSING_HEADER
+                    exception.args.shouldContainOnly("Idempotency-Key")
+                }
+            }
+
+            context("Idempotency-Key 헤더가 UUID 형식이 아닐 때") {
+                it("BusinessException(INVALID_IDEMPOTENCY_KEY)을 던진다") {
+                    setupSecurityContext()
+                    val request = cachedRequest(idempotencyKey = "not-a-uuid")
+                    val response = MockHttpServletResponse()
+                    val handler = handlerMethod()
+
+                    val exception = shouldThrow<BusinessException> {
+                        interceptor.preHandle(request, response, handler)
+                    }
+                    exception.errorCode shouldBe INVALID_IDEMPOTENCY_KEY
+                }
+            }
+
+            context("동일한 key와 hash의 캐시 응답이 있을 때") {
+                it("캐시 본문/상태/contentType을 응답에 세팅하고 false를 리턴한다") {
+                    setupSecurityContext()
+                    val key = UUID.randomUUID().toString()
+                    val bodyText = "cached body"
+                    val body = bodyText.toByteArray()
+                    val handler = handlerMethod()
+                    val hash = primeHash(
+                        request = cachedRequest(idempotencyKey = key, body = body),
+                        handler = handler,
+                    )
+                    every { idempotencyRepository.getCachedResponse(any()) } returns IdempotencyEntry(
+                        hash = hash,
+                        statusCode = 200,
+                        contentType = "application/json",
+                        body = bodyText,
+                    )
+
+                    val request = cachedRequest(idempotencyKey = key, body = body)
+                    val response = MockHttpServletResponse()
+
+                    val result = interceptor.preHandle(request, response, handler)
+
+                    result shouldBe false
+                    response.status shouldBe 200
+                    response.contentType?.startsWith("application/json") shouldBe true
+                    response.contentAsString shouldBe bodyText
+                }
+            }
+
+            context("동일한 key지만 다른 hash의 캐시 응답이 있을 때") {
+                it("BusinessException(IDEMPOTENCY_KEY_CONFLICT)을 던진다") {
+                    setupSecurityContext()
+                    val key = UUID.randomUUID().toString()
+                    val request = cachedRequest(idempotencyKey = key)
+                    val response = MockHttpServletResponse()
+                    val handler = handlerMethod()
+
+                    every { idempotencyRepository.getCachedResponse(any()) } returns IdempotencyEntry(
+                        hash = "different-hash-value",
+                        statusCode = 200,
+                        contentType = "application/json",
+                        body = "cached body",
+                    )
+
+                    val exception = shouldThrow<BusinessException> {
+                        interceptor.preHandle(request, response, handler)
+                    }
+                    exception.errorCode shouldBe IDEMPOTENCY_KEY_CONFLICT
+                }
+            }
+
+            context("동일한 key와 body지만, query string이 다를 때") {
+                it("hash 불일치로 BusinessException(IDEMPOTENCY_KEY_CONFLICT)을 던진다") {
+                    setupSecurityContext()
+                    val key = UUID.randomUUID().toString()
+                    val sharedBody = "{}".toByteArray()
+
+                    // given: 첫 번째 요청 진행
+                    val request1 = cachedRequest(idempotencyKey = key, query = "page=1", body = sharedBody)
+                    val response1 = MockHttpServletResponse()
+                    val handler = handlerMethod()
+                    every { idempotencyRepository.getCachedResponse(any()) } returns null
+                    every { idempotencyRepository.acquireIdempotencyProcessing(any(), any()) } returns true
+                    interceptor.preHandle(request1, response1, handler)
+
+                    // 두 번재 요청에서 사용될 스터빙 진행
+                    val storedHash = request1.getAttribute("caro.idempotency.hash") as String
+                    every { idempotencyRepository.getCachedResponse(any()) } returns IdempotencyEntry(
+                        hash = storedHash,
+                        statusCode = 200,
+                        contentType = "application/json",
+                        body = "result",
+                    )
+
+                    // when & then: 두 번째 요청 진행
+                    val request2 = cachedRequest(idempotencyKey = key, query = "page=2", body = sharedBody)
+                    val response2 = MockHttpServletResponse()
+                    val exception = shouldThrow<BusinessException> {
+                        interceptor.preHandle(request2, response2, handler)
+                    }
+                    exception.errorCode shouldBe IDEMPOTENCY_KEY_CONFLICT
+                }
+            }
+
+            context("동일 key와 body, query지만 path 끝의 trailing slash('/')만 다를 때") {
+                it("사전 정규화로 hash가 동일하기 때문에 캐시 응답이 재생된다") {
+                    setupSecurityContext()
+                    val key = UUID.randomUUID().toString()
+                    val bodyText = "body"
+                    val sharedBody = bodyText.toByteArray()
+
+                    // given: 첫 번째 요청 진행
+                    val request1 = cachedRequest(uri = "/api/v1/test", idempotencyKey = key, body = sharedBody)
+                    val response1 = MockHttpServletResponse()
+                    val handler = handlerMethod()
+                    every { idempotencyRepository.getCachedResponse(any()) } returns null
+                    every { idempotencyRepository.acquireIdempotencyProcessing(any(), any()) } returns true
+                    interceptor.preHandle(request1, response1, handler)
+
+                    // 두 번째 요청에서 사용될 스터빙 진행
+                    val storedHash = request1.getAttribute("caro.idempotency.hash") as String
+                    every { idempotencyRepository.getCachedResponse(any()) } returns IdempotencyEntry(
+                        hash = storedHash,
+                        statusCode = 200,
+                        contentType = "application/json",
+                        body = bodyText,
+                    )
+
+                    // when: 두 번째 요청 진행
+                    val request2 = cachedRequest(uri = "/api/v1/test/", idempotencyKey = key, body = sharedBody)
+                    val response2 = MockHttpServletResponse()
+                    val result = interceptor.preHandle(request2, response2, handler)
+
+                    // then
+                    result shouldBe false
+                    response2.status shouldBe 200
+                    response2.contentAsString shouldBe bodyText
+                }
+            }
+
+            context("캐시가 없고 acquire이 진행중일 때 새로운 요청이 들어온다면") {
+                it("BusinessException(IDEMPOTENCY_REQUEST_IN_PROGRESS)을 던진다") {
+                    setupSecurityContext()
+                    val request = cachedRequest()
+                    val response = MockHttpServletResponse()
+                    val handler = handlerMethod()
+
+                    every { idempotencyRepository.getCachedResponse(any()) } returns null
+                    every { idempotencyRepository.acquireIdempotencyProcessing(any(), any()) } returns false
+
+                    val exception = shouldThrow<BusinessException> {
+                        interceptor.preHandle(request, response, handler)
+                    }
+                    exception.errorCode shouldBe IDEMPOTENCY_REQUEST_IN_PROGRESS
+                }
+            }
+
+            context("처음 들어온 요청이라면") {
+                it("request에 redisKey/hash/cacheInternalErrorResponse attribute를 설정하고 true를 리턴한다") {
+                    val userId = 1L
+                    setupSecurityContext(userId = userId)
+                    val key = UUID.randomUUID().toString()
+                    val request = cachedRequest(idempotencyKey = key)
+                    val response = MockHttpServletResponse()
+                    val handler = handlerMethod(cacheInternalErrorResponse = false)
+
+                    every { idempotencyRepository.getCachedResponse(any()) } returns null
+                    every { idempotencyRepository.acquireIdempotencyProcessing(any(), any()) } returns true
+
+                    val result = interceptor.preHandle(request, response, handler)
+                    val expectedRedisKey = "idempotency:$userId:$key"
+
+                    result shouldBe true
+                    request.getAttribute("caro.idempotency.redisKey") shouldBe expectedRedisKey
+                    request.getAttribute("caro.idempotency.hash") shouldNotBe null
+                    request.getAttribute("caro.idempotency.hash") shouldNotBe null
+                    request.getAttribute("caro.idempotency.cacheInternalErrorResponse") shouldBe false
+
+                    verify { idempotencyRepository.acquireIdempotencyProcessing(expectedRedisKey, any()) }
+                }
+            }
+        }
+
+        describe("afterCompletion()") {
+            val defaultRedisKey = "idempotency:1:test-key"
+            val defaultHash = "test-hash"
+
+            fun requestWith(
+                redisKey: String = defaultRedisKey,
+                hash: String? = defaultHash,
+                cacheInternalErrorResponse: Boolean = false,
+            ): MockHttpServletRequest =
+                MockHttpServletRequest().apply {
+                    setAttribute("caro.idempotency.redisKey", redisKey)
+                    hash?.let { setAttribute("caro.idempotency.hash", it) }
+                    setAttribute("caro.idempotency.cacheInternalErrorResponse", cacheInternalErrorResponse)
+                }
+
+            fun wrappedResponseWith(
+                status: Int = 200,
+                contentType: String? = null,
+                body: ByteArray? = null,
+            ): ContentCachingResponseWrapper {
+                val wrapped = ContentCachingResponseWrapper(MockHttpServletResponse())
+                wrapped.status = status
+                contentType?.let { wrapped.contentType = it }
+                body?.let { wrapped.outputStream.write(it) }
+                return wrapped
+            }
+
+            context("redisKey/hash attribute가 없을 때") {
+                it("redisKey가 없으면 response 캐싱을 진행하지 않는다") {
+                    val request = MockHttpServletRequest()
+
+                    interceptor.afterCompletion(request, wrappedResponseWith(), handlerMethod(), null)
+
+                    verify(exactly = 0) { idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any()) }
+                    verify(exactly = 0) { idempotencyRepository.deleteIdempotencyProcessing(any()) }
+                }
+
+                it("redisKey는 있지만 hash가 없으면 response 캐싱을 진행하지 않는다") {
+                    val request = MockHttpServletRequest().apply {
+                        setAttribute("caro.idempotency.redisKey", defaultRedisKey)
+                    }
+
+                    interceptor.afterCompletion(request, wrappedResponseWith(), handlerMethod(), null)
+
+                    verify(exactly = 0) { idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any()) }
+                    verify(exactly = 0) { idempotencyRepository.deleteIdempotencyProcessing(any()) }
+                }
+            }
+
+            context("5xx대 응답이고 @Idempotent를 cacheInternalErrorResponse=false로 설정했다면") {
+                it("processing 마커를 제거하고 saveResponse는 호출하지 않는다") {
+                    val request = requestWith()
+                    val wrapped = wrappedResponseWith(status = 500)
+
+                    interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
+
+                    verify { idempotencyRepository.deleteIdempotencyProcessing(defaultRedisKey) }
+                    verify(exactly = 0) { idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any()) }
+                }
+            }
+
+            context("exception handler에서 처리되지 않은 예외가 있고 cacheInternalErrorResponse=false로 설정했다면") {
+                it("processing 마커를 제거하고 saveResponse는 호출하지 않는다") {
+                    val request = requestWith()
+                    val wrapped = wrappedResponseWith(status = 200)
+
+                    interceptor.afterCompletion(request, wrapped, handlerMethod(), RuntimeException("error"))
+
+                    verify { idempotencyRepository.deleteIdempotencyProcessing(defaultRedisKey) }
+                    verify(exactly = 0) { idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any()) }
+                }
+            }
+
+            context("5xx대 응답이고 cacheInternalErrorResponse=true로 설정했다면") {
+                it("saveResponse를 호출해 응답을 캐싱한다") {
+                    val bodyText = "error response"
+                    val request = requestWith(cacheInternalErrorResponse = true)
+                    val wrapped = wrappedResponseWith(
+                        status = 500,
+                        contentType = "application/json",
+                        body = bodyText.toByteArray(),
+                    )
+
+                    interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
+
+                    verify {
+                        idempotencyRepository.saveResponse(
+                            key = defaultRedisKey,
+                            hash = defaultHash,
+                            statusCode = 500,
+                            contentType = "application/json",
+                            body = bodyText,
+                            expiresIn = any(),
+                        )
+                    }
+                }
+            }
+
+            context("정상(2xx) 응답일 경우") {
+                it("saveResponse를 호출해 응답을 캐싱한다") {
+                    val bodyText = "success response"
+                    val request = requestWith()
+                    val wrapped = wrappedResponseWith(
+                        status = 200,
+                        contentType = "application/json",
+                        body = bodyText.toByteArray(),
+                    )
+
+                    interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
+
+                    verify {
+                        idempotencyRepository.saveResponse(
+                            key = defaultRedisKey,
+                            hash = defaultHash,
+                            statusCode = 200,
+                            contentType = "application/json",
+                            body = bodyText,
+                            expiresIn = any(),
+                        )
+                    }
+                }
+            }
+
+            context("정상 응답 response.contentType이 null일 때") {
+                it("saveResponse 호출 시 MediaType.APPLICATION_JSON_VALUE가 사용된다") {
+                    val request = requestWith()
+                    val wrapped = wrappedResponseWith(
+                        status = 200,
+                        body = "{}".toByteArray(),
+                    )
+
+                    interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
+
+                    verify {
+                        idempotencyRepository.saveResponse(
+                            any(),
+                            any(),
+                            any(),
+                            MediaType.APPLICATION_JSON_VALUE,
+                            any(),
+                            any(),
+                        )
+                    }
+                }
+            }
+
+            context("ContentCachingResponseWrapper로 wrap되지 않은 응답일 경우") {
+                it("응답을 캐싱하지 않으며 processing 마커를 제거한다") {
+                    val request = requestWith()
+                    val plainResponse = MockHttpServletResponse().apply { status = 200 }
+
+                    interceptor.afterCompletion(request, plainResponse, handlerMethod(), null)
+
+                    verify(exactly = 0) { idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any()) }
+                    verify { idempotencyRepository.deleteIdempotencyProcessing(defaultRedisKey) }
+                }
+            }
+
+            context("saveResponse에서 예외가 발생할 때") {
+                it("응답을 캐싱하지 않으며 processing 마커를 제거한다") {
+                    val request = requestWith()
+                    val wrapped = wrappedResponseWith()
+
+                    every {
+                        idempotencyRepository.saveResponse(any(), any(), any(), any(), any(), any())
+                    } throws RuntimeException("redis down")
+
+                    shouldThrow<RuntimeException> {
+                        interceptor.afterCompletion(request, wrapped, handlerMethod(), null)
+                    }
+
+                    verify { idempotencyRepository.deleteIdempotencyProcessing(defaultRedisKey) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyRepositoryTest.kt
@@ -1,0 +1,160 @@
+package com.whatever.caro.common.web.idempotency
+
+import com.whatever.caro.TestcontainersConfiguration
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.ranges.shouldBeIn
+import io.kotest.matchers.shouldBe
+import org.awaitility.Awaitility.await
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.modulith.test.ApplicationModuleTest
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+@ApplicationModuleTest
+@Import(TestcontainersConfiguration::class)
+class IdempotencyRepositoryTest(
+    private val repository: IdempotencyRepository,
+    private val redisTemplate: StringRedisTemplate,
+) : DescribeSpec({
+
+    val processingTtl: Duration = Duration.ofSeconds(30)
+    val responseTtl: Duration = Duration.ofHours(24)
+
+    afterEach {
+        redisTemplate.connectionFactory?.connection?.serverCommands()?.flushDb()
+    }
+
+    describe("acquireIdempotencyProcessing()") {
+        it("신규 키일 때 true를 리턴하고 processing 마커를 저장한다") {
+            val key = "idempotency:test-key-1"
+
+            val result = repository.acquireIdempotencyProcessing(key, processingTtl)
+
+            result shouldBe true
+            redisTemplate.hasKey("$key:processing") shouldBe true
+        }
+
+        it("이미 존재하는 키라면 false를 리턴한다") {
+            val key = "idempotency:test-key-2"
+            repository.acquireIdempotencyProcessing(key, processingTtl)
+
+            val result = repository.acquireIdempotencyProcessing(key, processingTtl)
+
+            result shouldBe false
+        }
+    }
+
+    describe("saveResponse()") {
+        it("response 키에 payload를 저장하고 processing 키를 삭제한다") {
+            val key = "idempotency:test-key-3"
+            repository.acquireIdempotencyProcessing(key, processingTtl)
+            redisTemplate.hasKey("$key:processing") shouldBe true
+
+            repository.saveResponse(
+                key = key,
+                hash = "abc123hash",
+                statusCode = 200,
+                contentType = "application/json",
+                body = """{"data":"hello"}""",
+                expiresIn = responseTtl,
+            )
+
+            redisTemplate.hasKey(key) shouldBe true
+            redisTemplate.hasKey("$key:processing") shouldBe false
+        }
+    }
+
+    describe("getCachedResponse()") {
+        it("저장된 response를 동일하게 조회한다") {
+            val key = "idempotency:test-key-4"
+            val hash = "abc123hash"
+            val status = 200
+            val contentType = "application/json"
+            val body = """{"data":"hello"}"""
+            repository.saveResponse(
+                key = key,
+                hash = hash,
+                statusCode = status,
+                contentType = contentType,
+                body = body,
+                expiresIn = responseTtl,
+            )
+
+            val cached = repository.getCachedResponse(key)
+
+            cached.shouldNotBeNull()
+            cached.hash shouldBe hash
+            cached.statusCode shouldBe status
+            cached.contentType shouldBe contentType
+            cached.body shouldBe body
+        }
+
+        it("존재하지 않는 키는 null을 리턴한다") {
+            val unknownKey = "idempotency:unknown-key"
+
+            val result = repository.getCachedResponse(unknownKey)
+
+            result shouldBe null
+        }
+    }
+
+    describe("deleteIdempotencyProcessing()") {
+        it("processing 마커를 삭제한다") {
+            val key = "idempotency:test-key-5"
+            repository.acquireIdempotencyProcessing(key, processingTtl)
+            redisTemplate.hasKey("$key:processing") shouldBe true
+
+            repository.deleteIdempotencyProcessing(key)
+
+            redisTemplate.hasKey("$key:processing") shouldBe false
+        }
+    }
+
+    describe("TTL test") {
+        it("saveResponse시 전달한 ttl이 설정된다") {
+            val key = "idempotency:test-key-6"
+
+            repository.saveResponse(
+                key = key,
+                hash = "hashval",
+                statusCode = 200,
+                contentType = "application/json",
+                body = "{}",
+                expiresIn = responseTtl,
+            )
+            val ttlSeconds = redisTemplate.getExpire(key, TimeUnit.SECONDS)
+
+            ttlSeconds shouldBeIn (responseTtl.seconds - 60..responseTtl.seconds)
+        }
+
+        it("ttl 만료 후 response 키가 자동 삭제된다") {
+            val key = "idempotency:test-key-7"
+            val shortTtl = Duration.ofSeconds(1)
+
+            repository.saveResponse(
+                key = key,
+                hash = "hashval",
+                statusCode = 200,
+                contentType = "application/json",
+                body = "{}",
+                expiresIn = shortTtl,
+            )
+            redisTemplate.hasKey(key) shouldBe true
+
+            await()
+                .pollDelay(shortTtl.minusMillis(100))
+                .between(
+                    shortTtl.minusMillis(100),
+                    shortTtl.plusMillis(100),
+                )
+                .untilAsserted {
+                    redisTemplate.hasKey(key) shouldBe false
+                }
+        }
+    }
+})


### PR DESCRIPTION
## 📌 Related Issue
Closes #33 

## 📝 Changes
- **Request body caching 인프라**: `CachedBodyHttpServletRequest` + `RequestResponseCachingFilter` 추가. SecurityFilterChain의 `JwtAuthenticationFilter` 이후 등록되며, `FilterRegistrationBean`으로 ServletContainer 자동 등록을 차단해 단일 실행 보장.
- **Idempotency**
  - `@Idempotent` 어노테이션
  - `IdempotencyInterceptor`
    - `Idempotency-Key`(UUID v4) 헤더와 SHA-256 method+path+body 해시로 중복 요청 차단
  - Redis 기반 `IdempotencyRepository`
  - 응답 캐시 TTL은 `app.idempotency.{response-ttl, processing-ttl}`로 설정
- **공용 에러 코드 추가**


## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
- redis lua script 사용에 사용된 `SETEX`를 권장 사용법인 `SET, EX`로 교체
- `@ConfigurationPropertiesScan`를 사용하여 ConfigurationProperties를 명시하지 않아도 스캔될 수 있도록 수정
- `@Component`로 등록한 Filter들이 Security filter chain과 Servlet container filter chain에 중복 등록되지 않도록 `SecurityFilterRegistrationConfig`에서 자동 등록 비활성화
- 요청 흐름 예시
  <img width="3278" height="2982" alt="diagram" src="https://github.com/user-attachments/assets/593d5e90-692b-4c60-81c0-e573c3c47b5d" />
