### PR TITLE
[Refactor] Swagger 응답 예시 추가 및 client 요청 반영

### DIFF
--- a/src/main/kotlin/com/whatever/caro/auth/internal/AuthService.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/AuthService.kt
@@ -31,6 +31,7 @@ class AuthService(
 ) {
     fun socialLogin(
         request: SocialLoginRequest,
+        deviceId: String,
     ): SocialLoginResponse {
         val verifier = socialIdTokenVerifierFactory.getVerifier(request.provider)
         val socialUserInfo = try {
@@ -56,14 +57,14 @@ class AuthService(
 
         refreshTokenRepository.save(
             userId = userInfo.id,
-            deviceId = request.deviceId,
+            deviceId = deviceId,
             refreshToken = refreshToken,
             accessTokenJti = generated.jti,
             expiresIn = jwtProperties.refreshTokenExpiresIn,
         )
 
         logger.info {
-            "Social login successful: userId=${userInfo.id}, provider=${request.provider}, deviceId=${request.deviceId}"
+            "Social login successful: userId=${userInfo.id}, provider=${request.provider}, deviceId=$deviceId"
         }
 
         return SocialLoginResponse(
@@ -111,13 +112,14 @@ class AuthService(
 
     fun reissueToken(
         request: RefreshTokenRequest,
+        deviceId: String,
     ): TokenResponse {
         val claims = jwtTokenProvider.parseAccessTokenAllowExpired(request.accessToken)
 
         val consumed = refreshTokenRepository.consumeToken(
             refreshToken = request.refreshToken,
             userId = claims.userId,
-            deviceId = request.deviceId,
+            deviceId = deviceId,
         ) ?: throw InvalidRefreshTokenException("유효하지 않은 Refresh Token입니다")
 
         tokenBlacklistRepository.add(consumed.accessTokenJti, jwtProperties.accessTokenExpiresIn)
@@ -129,13 +131,13 @@ class AuthService(
         val newRefreshToken = jwtTokenProvider.generateRefreshToken()
         refreshTokenRepository.save(
             claims.userId,
-            request.deviceId,
+            deviceId,
             newRefreshToken,
             generated.jti,
             jwtProperties.refreshTokenExpiresIn,
         )
 
-        logger.info { "Token refreshed: userId=${claims.userId}, deviceId=${request.deviceId}" }
+        logger.info { "Token refreshed: userId=${claims.userId}, deviceId=$deviceId" }
 
         return TokenResponse(accessToken = generated.token, refreshToken = newRefreshToken)
     }

--- a/src/main/kotlin/com/whatever/caro/auth/internal/AuthService.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/AuthService.kt
@@ -76,6 +76,7 @@ class AuthService(
     fun completeRegistration(
         authUser: AuthUser,
         request: CompleteRegistrationRequest,
+        deviceId: String,
     ): TokenResponse {
         val userInfo = userApi.completeRegistration(
             userId = authUser.userId,
@@ -95,13 +96,13 @@ class AuthService(
         val newRefreshToken = jwtTokenProvider.generateRefreshToken()
         refreshTokenRepository.save(
             userId = userInfo.id,
-            deviceId = request.deviceId,
+            deviceId = deviceId,
             refreshToken = newRefreshToken,
             accessTokenJti = generated.jti,
             expiresIn = jwtProperties.refreshTokenExpiresIn,
         )
 
-        logger.info { "Registration completed: userId=${authUser.userId}, deviceId=${request.deviceId}" }
+        logger.info { "Registration completed: userId=${authUser.userId}, deviceId=$deviceId" }
         return TokenResponse(
             accessToken = generated.token,
             refreshToken = newRefreshToken,

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/OAuth2Properties.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/OAuth2Properties.kt
@@ -12,7 +12,7 @@ data class OAuth2Properties(
     )
 
     data class AppleProperties(
-        val clientId: String,
+        val clientIds: Set<String>,
         val jwksUri: String,
     )
 }

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
@@ -48,10 +48,10 @@ class SecurityConfig(
             authorizeHttpRequests {
                 // staging 에서는 SwaggerSecurityConfig가 우선시되어 Basic Auth 필요
                 PublicEndpoints.PATTERNS.forEach { authorize(it, permitAll) }
-                authorize("/api/v1/auth/complete-registration", hasRole("SUSPENDED"))
-                authorize("/api/v1/nicknames/**", hasRole("SUSPENDED"))
-                authorize("/api/v1/users/nickname/**", hasRole("SUSPENDED"))
-                authorize("/api/v1/auth/logout", authenticated)
+                authorize("/v1/auth/complete-registration", hasRole("SUSPENDED"))
+                authorize("/v1/nicknames/**", hasRole("SUSPENDED"))
+                authorize("/v1/users/nickname/**", hasRole("SUSPENDED"))
+                authorize("/v1/auth/logout", authenticated)
                 authorize(anyRequest, hasRole("ACTIVE"))
             }
 

--- a/src/main/kotlin/com/whatever/caro/auth/internal/social/AppleIdTokenVerifier.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/social/AppleIdTokenVerifier.kt
@@ -73,7 +73,7 @@ class AppleIdTokenVerifier(
 
         return NimbusJwtDecoder.withJwkSource(jwkSource).build().also { decoder ->
             val audienceValidator = JwtClaimValidator<List<String>>(JwtClaimNames.AUD) { aud ->
-                aud != null && aud.contains(oauth2Properties.apple.clientId)
+                aud != null && aud.any { oauth2Properties.apple.clientIds.contains(it) }
             }
 
             val tokenValidator = DelegatingOAuth2TokenValidator(

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
@@ -33,9 +33,11 @@ class AuthController(
     @PublicApi
     @PostMapping("/social-login")
     fun socialLogin(
+        @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
+        @RequestHeader(name = "Device-Id", required = true) deviceId: String,
         @Valid @RequestBody request: SocialLoginRequest,
     ): ResponseEntity<ApiResponse<SocialLoginResponse>> {
-        val response = authService.socialLogin(request)
+        val response = authService.socialLogin(request, deviceId)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
@@ -45,9 +47,9 @@ class AuthController(
     )
     @PostMapping("/complete-registration")
     fun completeRegistration(
-        @Valid @RequestBody request: CompleteRegistrationRequest,
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
         @RequestHeader(name = "Device-Id", required = true) deviceId: String,
+        @Valid @RequestBody request: CompleteRegistrationRequest,
     ): ResponseEntity<ApiResponse<TokenResponse>> {
         val authUser = SecurityUtil.currentUser()
         val response = authService.completeRegistration(authUser, request, deviceId)
@@ -61,9 +63,11 @@ class AuthController(
     @PublicApi
     @PostMapping("/refresh")
     fun refreshToken(
+        @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
+        @RequestHeader(name = "Device-Id", required = true) deviceId: String,
         @Valid @RequestBody request: RefreshTokenRequest,
     ): ResponseEntity<ApiResponse<TokenResponse>> {
-        val response = authService.reissueToken(request)
+        val response = authService.reissueToken(request, deviceId)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
@@ -5,8 +5,11 @@ import com.whatever.caro.auth.internal.AuthService
 import com.whatever.caro.auth.internal.web.request.CompleteRegistrationRequest
 import com.whatever.caro.auth.internal.web.request.RefreshTokenRequest
 import com.whatever.caro.auth.internal.web.request.SocialLoginRequest
+import com.whatever.caro.auth.internal.web.response.SocialLoginResponse
+import com.whatever.caro.auth.internal.web.response.TokenResponse
 import com.whatever.caro.common.openapi.PublicApi
 import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -23,35 +26,51 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val authService: AuthService,
 ) {
+    @Operation(
+        summary = "소셜 로그인",
+        description = "소셜 ID 토큰을 검증해 access/refresh 토큰을 발급한다. 신규 사용자는 isRegistrationComplete=false 로 응답.",
+    )
     @PublicApi
     @PostMapping("/social-login")
     fun socialLogin(
         @Valid @RequestBody request: SocialLoginRequest,
-    ): ResponseEntity<ApiResponse<Any>> {
+    ): ResponseEntity<ApiResponse<SocialLoginResponse>> {
         val response = authService.socialLogin(request)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
+    @Operation(
+        summary = "회원가입 완료",
+        description = "닉네임/약관 동의 입력 후 access/refresh 토큰을 재발급한다.",
+    )
     @PostMapping("/complete-registration")
     fun completeRegistration(
         @Valid @RequestBody request: CompleteRegistrationRequest,
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
         @RequestHeader(name = "Device-Id", required = true) deviceId: String,
-    ): ResponseEntity<ApiResponse<Any>> {
+    ): ResponseEntity<ApiResponse<TokenResponse>> {
         val authUser = SecurityUtil.currentUser()
         val response = authService.completeRegistration(authUser, request, deviceId)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
+    @Operation(
+        summary = "토큰 재발급",
+        description = "Refresh Token 으로 access/refresh 토큰을 재발급한다. 단일 사용 정책.",
+    )
     @PublicApi
     @PostMapping("/refresh")
     fun refreshToken(
         @Valid @RequestBody request: RefreshTokenRequest,
-    ): ResponseEntity<ApiResponse<Any>> {
+    ): ResponseEntity<ApiResponse<TokenResponse>> {
         val response = authService.reissueToken(request)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
+    @Operation(
+        summary = "로그아웃",
+        description = "현재 access token 을 블랙리스트 처리하고 디바이스 refresh token 을 폐기한다.",
+    )
     @PostMapping("/logout")
     fun logout(
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
@@ -3,16 +3,17 @@ package com.whatever.caro.auth.internal.web
 import com.whatever.caro.auth.SecurityUtil
 import com.whatever.caro.auth.internal.AuthService
 import com.whatever.caro.auth.internal.web.request.CompleteRegistrationRequest
-import com.whatever.caro.auth.internal.web.request.LogoutRequest
 import com.whatever.caro.auth.internal.web.request.RefreshTokenRequest
 import com.whatever.caro.auth.internal.web.request.SocialLoginRequest
 import com.whatever.caro.common.openapi.PublicApi
 import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -34,9 +35,11 @@ class AuthController(
     @PostMapping("/complete-registration")
     fun completeRegistration(
         @Valid @RequestBody request: CompleteRegistrationRequest,
+        @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
+        @RequestHeader(name = "Device-Id", required = true) deviceId: String,
     ): ResponseEntity<ApiResponse<Any>> {
         val authUser = SecurityUtil.currentUser()
-        val response = authService.completeRegistration(authUser, request)
+        val response = authService.completeRegistration(authUser, request, deviceId)
         return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
@@ -51,10 +54,11 @@ class AuthController(
 
     @PostMapping("/logout")
     fun logout(
-        @Valid @RequestBody request: LogoutRequest,
+        @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
+        @RequestHeader(name = "Device-Id", required = true) deviceId: String,
     ): ResponseEntity<ApiResponse<Unit>> {
         val authUser = SecurityUtil.currentUser()
-        authService.logout(authUser, request.deviceId)
+        authService.logout(authUser, deviceId)
         return ResponseEntity.ok(ApiResponse.ok(Unit))
     }
 }

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/request/CompleteRegistrationRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/request/CompleteRegistrationRequest.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.auth.internal.web.request
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
@@ -9,6 +10,7 @@ data class CompleteRegistrationRequest(
     @field:Size(max = 50, message = "닉네임은 50자 이하여야 합니다")
     val nickname: String,
 
+    @get:JsonProperty("isTermsAgreed")
     @field:AssertTrue(message = "약관에 동의해야 합니다")
     val isTermsAgreed: Boolean,
 )

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/request/CompleteRegistrationRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/request/CompleteRegistrationRequest.kt
@@ -11,7 +11,4 @@ data class CompleteRegistrationRequest(
 
     @field:AssertTrue(message = "약관에 동의해야 합니다")
     val isTermsAgreed: Boolean,
-
-    @field:NotBlank(message = "Device ID는 필수입니다")
-    val deviceId: String,
 )

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/request/LogoutRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/request/LogoutRequest.kt
@@ -1,8 +1,0 @@
-package com.whatever.caro.auth.internal.web.request
-
-import jakarta.validation.constraints.NotBlank
-
-data class LogoutRequest(
-    @field:NotBlank(message = "Device ID는 필수입니다")
-    val deviceId: String,
-)

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/request/RefreshTokenRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/request/RefreshTokenRequest.kt
@@ -6,9 +6,6 @@ data class RefreshTokenRequest(
     @field:NotBlank(message = "Refresh Token은 필수입니다")
     val refreshToken: String,
 
-    @field:NotBlank(message = "Device ID는 필수입니다")
-    val deviceId: String,
-
     @field:NotBlank(message = "Access Token은 필수입니다")
     val accessToken: String,
 )

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/request/SocialLoginRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/request/SocialLoginRequest.kt
@@ -8,7 +8,4 @@ data class SocialLoginRequest(
 
     @field:NotBlank(message = "ID Token은 필수입니다")
     val idToken: String,
-
-    @field:NotBlank(message = "Device ID는 필수입니다")
-    val deviceId: String,
 )

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/response/SocialLoginResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/response/SocialLoginResponse.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.auth.internal.web.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(name = "SocialLoginResponse", description = "소셜 로그인 응답")
@@ -8,6 +9,8 @@ data class SocialLoginResponse(
     val accessToken: String,
     @field:Schema(description = "JWT Refresh Token", example = "<jwt-refresh-token>")
     val refreshToken: String,
-    @field:Schema(description = "신규 가입자는 false (회원가입 완료 필요), 기존 회원은 true", example = "false")
+
+    @get:JsonProperty("isRegistrationComplete")
+    @get:Schema(description = "신규 가입자는 false (회원가입 완료 필요), 기존 회원은 true", example = "false")
     val isRegistrationComplete: Boolean,
 )

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/response/SocialLoginResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/response/SocialLoginResponse.kt
@@ -1,7 +1,13 @@
 package com.whatever.caro.auth.internal.web.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "SocialLoginResponse", description = "소셜 로그인 응답")
 data class SocialLoginResponse(
+    @field:Schema(description = "JWT Access Token", example = "<jwt-access-token>")
     val accessToken: String,
+    @field:Schema(description = "JWT Refresh Token", example = "<jwt-refresh-token>")
     val refreshToken: String,
+    @field:Schema(description = "신규 가입자는 false (회원가입 완료 필요), 기존 회원은 true", example = "false")
     val isRegistrationComplete: Boolean,
 )

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/response/TokenResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/response/TokenResponse.kt
@@ -1,6 +1,11 @@
 package com.whatever.caro.auth.internal.web.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "TokenResponse", description = "토큰 발급/재발급 응답")
 data class TokenResponse(
+    @field:Schema(description = "JWT Access Token", example = "<jwt-access-token>")
     val accessToken: String,
+    @field:Schema(description = "JWT Refresh Token", example = "<jwt-refresh-token>")
     val refreshToken: String,
 )

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
@@ -7,6 +7,8 @@ import com.whatever.caro.card.internal.deck.dto.create.toDto
 import com.whatever.caro.card.internal.deck.dto.create.toResponse
 import com.whatever.caro.card.internal.deck.service.DeckService
 import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,12 +16,17 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Deck", description = "단어/표현 덱 관리")
 @RestController
 @RequestMapping("/v1/decks")
 class DeckController(
     private val deckService: DeckService,
 ) {
 
+    @Operation(
+        summary = "덱 생성",
+        description = "새 덱을 생성하고 기본 프리셋을 연결한다.",
+    )
     @PostMapping
     fun createDeck(
         @Valid @RequestBody createDeckRequest: CreateDeckRequest,

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/dto/create/CreateDeckResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/dto/create/CreateDeckResponse.kt
@@ -1,7 +1,13 @@
 package com.whatever.caro.card.internal.deck.dto.create
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "CreateDeckResponse", description = "덱 생성 응답")
 data class CreateDeckResponse(
+    @field:Schema(description = "덱 ID", example = "1")
     val id: Long = 0L,
+    @field:Schema(description = "덱 이름", example = "TOEIC 필수 단어")
     val deckName: String = "",
+    @field:Schema(description = "덱 설명", example = "직장인을 위한 핵심 어휘")
     val deckDescription: String = "",
 )

--- a/src/main/kotlin/com/whatever/caro/nickname/internal/web/NicknameController.kt
+++ b/src/main/kotlin/com/whatever/caro/nickname/internal/web/NicknameController.kt
@@ -3,18 +3,25 @@ package com.whatever.caro.nickname.internal.web
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.nickname.NicknameApi
 import com.whatever.caro.nickname.internal.web.response.NicknameResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Nickname", description = "닉네임 추천")
 @RestController
 @RequestMapping("/v1/nicknames")
 class NicknameController(
     private val nicknameService: NicknameApi,
 ) {
 
+    @Operation(
+        summary = "랜덤 닉네임 1개 발급",
+        description = "Accept-Language 헤더 로케일에 맞춘 랜덤 닉네임을 반환한다.",
+    )
     @GetMapping("/random")
     fun getRandomNickname(): ResponseEntity<ApiResponse<NicknameResponse>> {
         val locale = LocaleContextHolder.getLocale()

--- a/src/main/kotlin/com/whatever/caro/nickname/internal/web/response/NicknameResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/nickname/internal/web/response/NicknameResponse.kt
@@ -1,5 +1,9 @@
 package com.whatever.caro.nickname.internal.web.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "NicknameResponse", description = "랜덤 닉네임 응답")
 data class NicknameResponse(
+    @field:Schema(description = "추천 닉네임", example = "다정한 고슴도치")
     val nickname: String,
 )

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
@@ -3,6 +3,8 @@ package com.whatever.caro.user.internal.web
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.user.UserApi
 import com.whatever.caro.user.internal.web.response.NicknameCheckResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import org.springframework.http.ResponseEntity
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "User", description = "사용자 정보 조회")
 @Validated
 @RestController
 @RequestMapping("/v1/users")
@@ -19,11 +22,15 @@ class UserController(
     private val userApi: UserApi,
 ) {
 
+    @Operation(
+        summary = "닉네임 사용 가능 여부 조회",
+        description = "닉네임 중복 여부를 반환한다. 길이 제한 50자.",
+    )
     @GetMapping("/nicknames/{nickname}/availability")
     fun checkNicknameAvailability(
         @PathVariable
         @NotBlank(message = "Nickname is required")
-        @Size(max = 50, message = "Nickname is required")
+        @Size(max = 50, message = "Nickname must be 50 characters or fewer")
         nickname: String,
     ): ResponseEntity<ApiResponse<NicknameCheckResponse>> {
         val available = userApi.isNicknameAvailable(nickname)

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/response/NicknameCheckResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/response/NicknameCheckResponse.kt
@@ -1,6 +1,11 @@
 package com.whatever.caro.user.internal.web.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "NicknameCheckResponse", description = "닉네임 사용 가능 여부 응답")
 data class NicknameCheckResponse(
+    @field:Schema(description = "조회 대상 닉네임", example = "다정한 고슴도치")
     val nickname: String,
+    @field:Schema(description = "사용 가능 여부 (true=사용 가능, false=중복)", example = "true")
     val available: Boolean,
 )

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -21,7 +21,9 @@ app:
     google:
       client-id: local-google-client-id
     apple:
-      client-id: local-apple-client-id
+      client-ids:
+        - local-apple-client-id-1
+        - local-apple-client-id-2
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,7 +50,7 @@ app:
     google:
       client-id: ${GOOGLE_CLIENT_ID}
     apple:
-      client-id: ${APPLE_CLIENT_ID}
+      client-ids: ${APPLE_CLIENT_ID}
       jwks-uri: https://appleid.apple.com/auth/keys
 
 server:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -121,3 +121,5 @@ springdoc:
     display-request-duration: true
   packages-to-scan: com.whatever.caro
   paths-to-match: /api/**, /v1/**
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json

--- a/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
@@ -162,8 +162,8 @@ class AuthServiceTest(
                 request = CompleteRegistrationRequest(
                     nickname = "ReturningUser",
                     isTermsAgreed = true,
-                    deviceId = deviceId,
                 ),
+                deviceId = deviceId,
             )
 
             // 2차 로그인 (기존 ACTIVE 사용자)
@@ -218,8 +218,8 @@ class AuthServiceTest(
                 request = CompleteRegistrationRequest(
                     nickname = nickname,
                     isTermsAgreed = true,
-                    deviceId = deviceId,
                 ),
+                deviceId = deviceId,
             )
 
             val newClaims = jwtTokenProvider.parseAccessToken(registrationResult.accessToken)
@@ -254,8 +254,8 @@ class AuthServiceTest(
                 request = CompleteRegistrationRequest(
                     nickname = "BlacklistUser",
                     isTermsAgreed = true,
-                    deviceId = deviceId,
                 ),
+                deviceId = deviceId,
             )
             val newClaims = jwtTokenProvider.parseAccessToken(registrationResult.accessToken)
 

--- a/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
@@ -79,13 +79,13 @@ class AuthServiceTest(
     describe("socialLogin") {
         it("신규 사용자 소셜 로그인 시 isRegistrationComplete=false이고 토큰이 발급된다") {
             stubSocialVerifier(providerUserId = "new-user-001")
+            val deviceId = "device-1"
             val request = SocialLoginRequest(
                 provider = SocialProvider.GOOGLE,
                 idToken = TEST_ID_TOKEN,
-                deviceId = "device-1",
             )
 
-            val result = authService.socialLogin(request)
+            val result = authService.socialLogin(request, deviceId)
 
             result.isRegistrationComplete shouldBe false
             result.accessToken.shouldNotBeEmpty()
@@ -101,10 +101,9 @@ class AuthServiceTest(
             val request = SocialLoginRequest(
                 provider = SocialProvider.GOOGLE,
                 idToken = TEST_ID_TOKEN,
-                deviceId = deviceId,
             )
 
-            val result = authService.socialLogin(request)
+            val result = authService.socialLogin(request, deviceId)
             val claims = jwtTokenProvider.parseAccessToken(result.accessToken)
 
             redisTemplate.opsForValue().get("refresh:${claims.userId}:$deviceId") shouldBe result.refreshToken
@@ -120,8 +119,8 @@ class AuthServiceTest(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val firstClaims = jwtTokenProvider.parseAccessToken(firstLogin.accessToken)
 
@@ -130,8 +129,8 @@ class AuthServiceTest(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val secondClaims = jwtTokenProvider.parseAccessToken(secondLogin.accessToken)
 
@@ -147,8 +146,8 @@ class AuthServiceTest(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val firstClaims = jwtTokenProvider.parseAccessToken(firstLogin.accessToken)
 
@@ -171,14 +170,15 @@ class AuthServiceTest(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
 
             secondLogin.isRegistrationComplete shouldBe true
         }
 
         it("ID 토큰 검증 실패 시 InvalidSocialTokenException을 던진다") {
+            val deviceId = "device-1"
             every { socialIdTokenVerifierFactory.getVerifier(SocialProvider.GOOGLE) } returns mockVerifier
             every { mockVerifier.verify(any()) } throws RuntimeException("verification failed")
 
@@ -187,8 +187,8 @@ class AuthServiceTest(
                     SocialLoginRequest(
                         provider = SocialProvider.GOOGLE,
                         idToken = "invalid-token",
-                        deviceId = "device-1",
                     ),
+                    deviceId,
                 )
             }
         }
@@ -198,13 +198,12 @@ class AuthServiceTest(
         it("등록 완료 시 새 access token에 ACTIVE status가 포함된다") {
             stubSocialVerifier(providerUserId = "reg-complete-user")
             val deviceId = "device-1"
-
             val loginResult = authService.socialLogin(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val loginClaims = jwtTokenProvider.parseAccessToken(loginResult.accessToken)
 
@@ -235,13 +234,12 @@ class AuthServiceTest(
         it("등록 완료 시 이전 access token JTI가 블랙리스트에 추가된다") {
             stubSocialVerifier(providerUserId = "blacklist-check-user")
             val deviceId = "device-1"
-
             val loginResult = authService.socialLogin(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val loginClaims = jwtTokenProvider.parseAccessToken(loginResult.accessToken)
 
@@ -268,22 +266,21 @@ class AuthServiceTest(
         it("정상 토큰 갱신 시 새 토큰이 발급되고 이전 JTI가 블랙리스트에 추가된다") {
             stubSocialVerifier(providerUserId = "reissue-user")
             val deviceId = "device-1"
-
             val loginResult = authService.socialLogin(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val loginClaims = jwtTokenProvider.parseAccessToken(loginResult.accessToken)
 
             val reissueResult = authService.reissueToken(
                 RefreshTokenRequest(
                     refreshToken = loginResult.refreshToken,
-                    deviceId = deviceId,
                     accessToken = loginResult.accessToken,
                 ),
+                deviceId,
             )
             val newClaims = jwtTokenProvider.parseAccessToken(reissueResult.accessToken)
 
@@ -299,22 +296,21 @@ class AuthServiceTest(
         it("유효하지 않은 refresh token 시 예외를 던진다") {
             stubSocialVerifier(providerUserId = "invalid-refresh-user")
             val deviceId = "device-1"
-
             val loginResult = authService.socialLogin(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
 
             shouldThrow<InvalidRefreshTokenException> {
                 authService.reissueToken(
                     RefreshTokenRequest(
                         refreshToken = "wrong-refresh-token",
-                        deviceId = deviceId,
                         accessToken = loginResult.accessToken,
                     ),
+                    deviceId,
                 )
             }
         }
@@ -328,13 +324,14 @@ class AuthServiceTest(
             val wrongProvider = JwtTokenProvider(wrongProperties, java.time.Clock.systemUTC()).apply { init() }
             val wrongToken = wrongProvider.generateAccessToken(1L, UserStatus.ACTIVE.name)
 
+            val deviceId = "device-1"
             shouldThrow<io.jsonwebtoken.security.SignatureException> {
                 authService.reissueToken(
                     RefreshTokenRequest(
                         refreshToken = "any-refresh",
-                        deviceId = "device-1",
                         accessToken = wrongToken.token,
                     ),
+                    deviceId,
                 )
             }
         }
@@ -344,13 +341,12 @@ class AuthServiceTest(
         it("로그아웃 시 access token이 블랙리스트에 추가되고 refresh token이 삭제된다") {
             stubSocialVerifier(providerUserId = "logout-user")
             val deviceId = "device-1"
-
             val loginResult = authService.socialLogin(
                 SocialLoginRequest(
                     provider = SocialProvider.GOOGLE,
                     idToken = TEST_ID_TOKEN,
-                    deviceId = deviceId,
                 ),
+                deviceId,
             )
             val loginClaims = jwtTokenProvider.parseAccessToken(loginResult.accessToken)
 

--- a/src/test/kotlin/com/whatever/caro/auth/internal/config/SwaggerStagingBasicAuthTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/config/SwaggerStagingBasicAuthTest.kt
@@ -29,7 +29,7 @@ private fun basicAuthHeader(
     properties = [
         "JWT_SECRET=test-secret-key-must-be-at-least-32-bytes-long-for-hs256",
         "GOOGLE_CLIENT_ID=test-google",
-        "APPLE_CLIENT_ID=test-apple",
+        "APPLE_CLIENT_ID=test-apple-1,test-apple-2",
         "DB_URL=jdbc:mysql://dummy:3306/dummy",
         "DB_USERNAME=dummy",
         "DB_PASSWORD=dummy",

--- a/src/test/kotlin/com/whatever/caro/auth/internal/social/AppleIdTokenVerifierTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/social/AppleIdTokenVerifierTest.kt
@@ -56,7 +56,7 @@ class AppleIdTokenVerifierTest(
         .build()
     val jwksJson = JWKSet(rsaKey).toString()
 
-    val clientId = "com.test.caro"
+    val clientIds = setOf("com.test.caro.1", "com.test.caro.2")
     val appleIssuer = "https://appleid.apple.com"
     val jwksUri = "https://appleid.apple.com/auth/keys"
 
@@ -70,7 +70,7 @@ class AppleIdTokenVerifierTest(
         val properties = OAuth2Properties(
             google = OAuth2Properties.GoogleProperties(clientId = "unused"),
             apple = OAuth2Properties.AppleProperties(
-                clientId = clientId,
+                clientIds = clientIds,
                 jwksUri = jwksUri,
             ),
         )
@@ -85,7 +85,7 @@ class AppleIdTokenVerifierTest(
     fun buildIdToken(
         sub: String? = DEFAULT_PROVIDER_USER_ID,
         iss: String = appleIssuer,
-        aud: String = clientId,
+        aud: String = clientIds.last(),
         exp: Date = Date.from(Instant.now().plus(Duration.ofMinutes(10))),
         iat: Date = Date.from(Instant.now()),
         email: String? = "user@example.com",

--- a/src/test/kotlin/com/whatever/caro/common/config/SwaggerDisabledInProdTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/config/SwaggerDisabledInProdTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.get
     properties = [
         "JWT_SECRET=test-secret-key-must-be-at-least-32-bytes-long-for-hs256",
         "GOOGLE_CLIENT_ID=test-google-client-id",
-        "APPLE_CLIENT_ID=test-apple-client-id",
+        "APPLE_CLIENT_ID=test-apple-client-id-1,test-apple-client-id-2",
         "DB_URL=jdbc:mysql://dummy:3306/dummy",
         "DB_USERNAME=dummy",
         "DB_PASSWORD=dummy",


### PR DESCRIPTION
## 📌 Related Issue
Closes #

## 📝 Changes
원래는 Swagger 응답 예시 추가만 하려 했는데, 작업 중 client 요청이 들어와 같은 브랜치에서 함께 처리했습니다

### 1) Swagger 응답 예시 & 스키마 정리
- AuthController, DeckController, NicknameController, UserController에 `@Operation` / 성공 응답 예시 추가
- 응답 DTO 정리: `SocialLoginResponse`, `TokenResponse`, `NicknameResponse`, `NicknameCheckResponse`, `CreateDeckResponse`
- 필드명의 `is` 접두사로 Swagger 스키마에서 필드명이 잘못 노출되던 문제 해결

### 2) Client 요청 반영 (Breaking)
- **`Device-Id`를 request body → HTTP Header로 이동**
  - 영향 API: `/social-login`, `/complete-registration`, `/refresh`, `/logout`
  - `LogoutRequest` 제거, 각 request DTO에서 `deviceId` 필드 제거
- **AuthController endpoint의 `/api` 접두사 제거**
  - context-path와 중복되어 `/api/api/...` 가 되는 문제 정리
- Android Apple 로그인 대응을 위해 Apple `clientId`를 **Set 타입**으로 변경 (다중 client id 허용)
  - firebase auth에서는 client에서 로그인을 진행할 때 server client id를 별도로 설정해주는 기능이 없다고 하더라고요
  - 그래서 firebase auth 프로젝트의 client id별로 bakend에 설정해주었습니다
  - `dev & qa client id`는 staging backend에, `prod client id`는 prod backend에

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료
- [x] 클라이언트 확인

## 📋 Additional Notes(Optional)
