### PR TITLE
[Feat] deck 상세 화면에 필요한 study module read 기능 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN chmod +x /app/entrypoint.sh
 
 USER app
 
+ENV TZ=UTC
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom"
 #ENV SPRING_PROFILES_ACTIVE=staging
 #ENV INFISICAL_ENV=staging

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,4 +205,5 @@ tasks.named("check") {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    systemProperty("user.timezone", "UTC")
 }

--- a/src/main/kotlin/com/whatever/caro/bff/ModuleMetadata.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/ModuleMetadata.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.bff
+
+import org.springframework.modulith.ApplicationModule
+import org.springframework.modulith.PackageInfo
+
+@PackageInfo
+@ApplicationModule(
+    displayName = "BackendForFrontend",
+    allowedDependencies = ["common", "study"],
+)
+class ModuleMetadata

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -1,0 +1,11 @@
+package com.whatever.caro.bff.internal.web
+
+import com.whatever.caro.study.StudyApi
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("/v1/decks")
+class DeckBFFController(
+    private val studyApi: StudyApi,
+) {
+    // TODO card 모듈 merge 후 추가구현
+}

--- a/src/main/kotlin/com/whatever/caro/study/CardLearningStateDto.kt
+++ b/src/main/kotlin/com/whatever/caro/study/CardLearningStateDto.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.study
+
+data class CardLearningStateDto(
+    val cardId: Long,
+    val totalReviews: Int,
+    val consecutiveAgainCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -5,16 +5,14 @@ import java.time.Instant
 interface StudyApi {
     /**
      * 오늘 학습 세션에 대한 정보를 반환한다.
-     * 만약 BEFORE/REST 상태와 같이 학습 정보가 없다면 null을 반환한다.
      *
-     * 시각은 caller(요청 진입 시점)가 결정한 단일 [now]를 전달받아 도메인 호출 간 일관성을 보장한다.
-     * 같은 study 모듈의 [com.whatever.caro.study.StudyTargetPoolCalculator.getTodayPool]와 동일 패턴.
+     * 시각은 caller(요청 진입 시점)가 결정한 단일 `now`를 전달받아 도메인 호출 간 일관성을 보장한다.
      */
     fun getTodaySummary(
         now: Instant,
         userId: Long,
         deckId: Long,
-    ): TodaySummaryDto?
+    ): TodaySummaryDto
 
     /**
      * 카드별 학습 상태를 cardId 기준 맵으로 반환한다.

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -1,0 +1,27 @@
+package com.whatever.caro.study
+
+import java.time.Instant
+
+interface StudyApi {
+    /**
+     * 오늘 학습 세션에 대한 정보를 반환한다.
+     * 만약 BEFORE/REST 상태와 같이 학습 정보가 없다면 null을 반환한다.
+     *
+     * 시각은 caller(요청 진입 시점)가 결정한 단일 [now]를 전달받아 도메인 호출 간 일관성을 보장한다.
+     * 같은 study 모듈의 [com.whatever.caro.study.StudyTargetPoolCalculator.getTodayPool]와 동일 패턴.
+     */
+    fun getTodaySummary(
+        now: Instant,
+        userId: Long,
+        deckId: Long,
+    ): TodaySummaryDto?
+
+    /**
+     * 카드별 학습 상태를 cardId 기준 맵으로 반환한다.
+     * 평가 이력이 없는 카드는 맵에 포함되지 않으므로, 호출 측에서 부재를 처리한다.
+     */
+    fun getLearningStates(
+        userId: Long,
+        cardIds: Collection<Long>,
+    ): Map<Long, CardLearningStateDto>
+}

--- a/src/main/kotlin/com/whatever/caro/study/StudyTargetPoolCalculator.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyTargetPoolCalculator.kt
@@ -1,0 +1,71 @@
+package com.whatever.caro.study
+
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.math.min
+
+@Component
+class StudyTargetPoolCalculator(
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getTodayPool(
+        now: Instant,
+        userId: Long,
+        timezone: ZoneId,
+        deckId: Long,
+        newCardPerDay: Int,
+        reviewCardPerDay: Int,
+        dayCutoffHour: Int,
+    ): StudyTargetPoolCount {
+        val nextSessionStart = getNextSessionStart(now, timezone, dayCutoffHour)
+
+        val newTargetCount = cardLearningStateRepository.countNewCards(
+            userId = userId,
+            deckId = deckId,
+        )
+        val reviewTargetCount = cardLearningStateRepository.countTodayReviewCards(
+            userId = userId,
+            deckId = deckId,
+            nextSessionStart = nextSessionStart,
+        )
+
+        val newPool = min(newCardPerDay, newTargetCount)
+        val reviewPool = min(reviewCardPerDay, reviewTargetCount)
+
+        return StudyTargetPoolCount(
+            newCount = newPool,
+            reviewCount = reviewPool,
+        )
+    }
+
+    /**
+     * dayCutoff를 반영한 timezone의 `오늘`을 반환
+     */
+    private fun getToday(
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ): LocalDate = now.atZone(timezone).minusHours(dayCutoffHour.toLong()).toLocalDate()
+
+    private fun getNextSessionStart(
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ): Instant =
+        getToday(now, timezone, dayCutoffHour)
+            .plusDays(1)
+            .atTime(dayCutoffHour, 0)
+            .atZone(timezone)
+            .toInstant()
+}
+
+data class StudyTargetPoolCount(
+    val newCount: Int,
+    val reviewCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/study/TodaySummaryDto.kt
+++ b/src/main/kotlin/com/whatever/caro/study/TodaySummaryDto.kt
@@ -5,4 +5,8 @@ data class TodaySummaryDto(
     val studiedCardCount: Int,
     val totalCardCount: Int,
     val sessionId: Long?,
-)
+) {
+    companion object {
+        fun notStarted() = TodaySummaryDto(TodaySummaryState.NOT_STARTED, 0, 0, null)
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/study/TodaySummaryDto.kt
+++ b/src/main/kotlin/com/whatever/caro/study/TodaySummaryDto.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.study
+
+data class TodaySummaryDto(
+    val state: TodaySummaryState,
+    val studiedCardCount: Int,
+    val totalCardCount: Int,
+    val sessionId: Long?,
+)

--- a/src/main/kotlin/com/whatever/caro/study/TodaySummaryState.kt
+++ b/src/main/kotlin/com/whatever/caro/study/TodaySummaryState.kt
@@ -1,9 +1,7 @@
 package com.whatever.caro.study
 
-// TODO 위치 고민
 enum class TodaySummaryState {
-    BEFORE,
+    NOT_STARTED,
     IN_PROGRESS,
     COMPLETED,
-    REST,
 }

--- a/src/main/kotlin/com/whatever/caro/study/TodaySummaryState.kt
+++ b/src/main/kotlin/com/whatever/caro/study/TodaySummaryState.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro.study
+
+// TODO 위치 고민
+enum class TodaySummaryState {
+    BEFORE,
+    IN_PROGRESS,
+    COMPLETED,
+    REST,
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -1,0 +1,80 @@
+package com.whatever.caro.study.internal
+
+import com.whatever.caro.study.CardLearningStateDto
+import com.whatever.caro.study.StudyApi
+import com.whatever.caro.study.StudySessionStatus
+import com.whatever.caro.study.TodaySummaryDto
+import com.whatever.caro.study.TodaySummaryState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import com.whatever.caro.study.internal.studysession.StudySession
+import com.whatever.caro.study.internal.studysession.StudySessionRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class StudyService(
+    private val studySessionRepository: StudySessionRepository,
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) : StudyApi {
+
+    override fun getTodaySummary(
+        now: Instant,
+        userId: Long,
+        deckId: Long,
+    ): TodaySummaryDto? {
+        val latestSession = studySessionRepository.findByUserAndDeckOrderByStartedAtDesc(userId, deckId) ?: return null
+
+        return when (latestSession.status) {
+            StudySessionStatus.ACTIVE -> {
+                if (latestSession.isTodaySession(now)) {
+                    latestSession.toTodaySummaryDto(TodaySummaryState.IN_PROGRESS)
+                } else {
+                    val effectedRow = studySessionRepository.setStoppedIfActive(latestSession.id)
+                    logger.warn {
+                        "Stale active study session detected. sessionId=${latestSession.id} effected row: $effectedRow"
+                    }
+                    null
+                }
+            }
+
+            StudySessionStatus.COMPLETED -> {
+                if (latestSession.isTodaySession(now)) {
+                    latestSession.toTodaySummaryDto(TodaySummaryState.COMPLETED)
+                } else {
+                    null
+                }
+            }
+
+            StudySessionStatus.STOPPED -> null
+        }
+    }
+
+    override fun getLearningStates(
+        userId: Long,
+        cardIds: Collection<Long>,
+    ): Map<Long, CardLearningStateDto> {
+        val learningStates = cardLearningStateRepository.findAllByUserIdAndCardIdIn(userId, cardIds)
+        return learningStates.associate { it.cardId to it.toDto() }
+    }
+}
+
+private fun StudySession.toTodaySummaryDto(
+    state: TodaySummaryState,
+): TodaySummaryDto =
+    TodaySummaryDto(
+        state = state,
+        studiedCardCount = newCardsStudied + reviewCardsStudied,
+        totalCardCount = estimatedTotal,
+        sessionId = id,
+    )
+
+private fun CardLearningState.toDto(): CardLearningStateDto =
+    CardLearningStateDto(
+        cardId = cardId,
+        totalReviews = totalReviews,
+        consecutiveAgainCount = consecutiveAgainCount,
+    )

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -25,31 +25,28 @@ class StudyService(
         now: Instant,
         userId: Long,
         deckId: Long,
-    ): TodaySummaryDto? {
-        val latestSession = studySessionRepository.findByUserAndDeckOrderByStartedAtDesc(userId, deckId) ?: return null
+    ): TodaySummaryDto {
+        val latestSession = studySessionRepository.findByUserAndDeckOrderByStartedAtDesc(userId, deckId)
+            ?: return TodaySummaryDto.notStarted()
+
+        if (latestSession.isTodaySession(now).not()) {
+            handleStaleSession(latestSession)
+            return TodaySummaryDto.notStarted()
+        }
 
         return when (latestSession.status) {
-            StudySessionStatus.ACTIVE -> {
-                if (latestSession.isTodaySession(now)) {
-                    latestSession.toTodaySummaryDto(TodaySummaryState.IN_PROGRESS)
-                } else {
-                    val effectedRow = studySessionRepository.setStoppedIfActive(latestSession.id)
-                    logger.warn {
-                        "Stale active study session detected. sessionId=${latestSession.id} effected row: $effectedRow"
-                    }
-                    null
-                }
-            }
+            StudySessionStatus.ACTIVE -> latestSession.toTodaySummaryDto(TodaySummaryState.IN_PROGRESS)
+            StudySessionStatus.COMPLETED -> latestSession.toTodaySummaryDto(TodaySummaryState.COMPLETED)
+            StudySessionStatus.STOPPED -> TodaySummaryDto.notStarted()
+        }
+    }
 
-            StudySessionStatus.COMPLETED -> {
-                if (latestSession.isTodaySession(now)) {
-                    latestSession.toTodaySummaryDto(TodaySummaryState.COMPLETED)
-                } else {
-                    null
-                }
-            }
-
-            StudySessionStatus.STOPPED -> null
+    private fun handleStaleSession(
+        latestSession: StudySession,
+    ) {
+        val effectedRow = studySessionRepository.setStoppedIfActive(latestSession.id)
+        logger.warn {
+            "Stale active study session detected. sessionId=${latestSession.id} effected row: $effectedRow"
         }
     }
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningState.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningState.kt
@@ -19,6 +19,9 @@ class CardLearningState(
     @Column(name = "card_id", nullable = false, unique = true)
     val cardId: Long,
 
+    @Column(name = "deck_id", nullable = false)
+    val deckId: Long,
+
     @Column(name = "user_id", nullable = false)
     val userId: Long,
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -1,5 +1,40 @@
 package com.whatever.caro.study.internal.cardlearningstate
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.Instant
 
-interface CardLearningStateRepository : JpaRepository<CardLearningState, Long>
+interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
+    fun findAllByUserIdAndCardIdIn(
+        userId: Long,
+        cardIds: Collection<Long>,
+    ): List<CardLearningState>
+
+    @Query(
+        """
+        select count(*) from CardLearningState cls
+        where cls.userId = :userId
+            and cls.deckId = :deckId
+            and cls.nextReviewAt < :nextSessionStart
+            and cls.status = CardLearningStatus.REVIEW
+    """,
+    )
+    fun countTodayReviewCards(
+        userId: Long,
+        deckId: Long,
+        nextSessionStart: Instant,
+    ): Int
+
+    @Query(
+        """
+        select count(*) from CardLearningState cls
+        where cls.userId = :userId
+            and cls.deckId = :deckId
+            and cls.status = CardLearningStatus.NEW
+    """,
+    )
+    fun countNewCards(
+        userId: Long,
+        deckId: Long,
+    ): Int
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -62,4 +62,8 @@ class StudySession(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L
+
+    fun isTodaySession(
+        now: Instant,
+    ): Boolean = sessionDate == now.atZone(timezone).minusHours(dayCutoffHour.toLong()).toLocalDate()
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepository.kt
@@ -1,5 +1,35 @@
 package com.whatever.caro.study.internal.studysession
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
-interface StudySessionRepository : JpaRepository<StudySession, Long>
+interface StudySessionRepository : JpaRepository<StudySession, Long> {
+
+    @Query(
+        """
+        select ss from StudySession ss
+        where ss.userId = :userId
+          and ss.deckId = :deckId
+        order by ss.startedAt desc limit 1
+    """,
+    )
+    fun findByUserAndDeckOrderByStartedAtDesc(
+        userId: Long,
+        deckId: Long,
+    ): StudySession?
+
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(
+        """
+        update StudySession ss set ss.status = StudySessionStatus.STOPPED
+        where ss.id = :id
+          and ss.status = StudySessionStatus.ACTIVE
+    """,
+    )
+    fun setStoppedIfActive(
+        id: Long,
+    ): Int
+}

--- a/src/main/resources/db/migration/study/V4__card_learning_state_add_deck_id.sql
+++ b/src/main/resources/db/migration/study/V4__card_learning_state_add_deck_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE card_learning_states
+    ADD COLUMN deck_id BIGINT NOT NULL;

--- a/src/test/kotlin/com/whatever/caro/ModularityTests.kt
+++ b/src/test/kotlin/com/whatever/caro/ModularityTests.kt
@@ -26,7 +26,7 @@ class ModularityTests :
 
             it("모듈이 올바르게 감지되었는지 확인한다") {
                 val moduleCount = modules.stream().count()
-                moduleCount shouldBe 6
+                moduleCount shouldBe 7
             }
         }
 

--- a/src/test/kotlin/com/whatever/caro/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/com/whatever/caro/TestcontainersConfiguration.kt
@@ -12,7 +12,9 @@ class TestcontainersConfiguration {
 
     @Bean
     @ServiceConnection
-    fun mysqlContainer(): MySQLContainer = MySQLContainer(DockerImageName.parse(MYSQL_VERSION))
+    fun mysqlContainer(): MySQLContainer =
+        MySQLContainer(DockerImageName.parse(MYSQL_VERSION))
+            .withUrlParam("connectionTimeZone", "UTC")
 
     @Bean
     @ServiceConnection(name = "redis")

--- a/src/test/kotlin/com/whatever/caro/study/StudyTargetPoolCalculatorTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/StudyTargetPoolCalculatorTest.kt
@@ -1,0 +1,142 @@
+package com.whatever.caro.study
+
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class StudyTargetPoolCalculatorTest :
+    DescribeSpec({
+        val kstZoneId = ZoneId.of("Asia/Seoul")
+        val baseNow = Instant.parse("2026-05-18T10:00:00Z")
+
+        fun createCalculator(): Pair<StudyTargetPoolCalculator, CardLearningStateRepository> {
+            val repo = mockk<CardLearningStateRepository>(relaxed = true)
+            val calc = StudyTargetPoolCalculator(cardLearningStateRepository = repo)
+            return calc to repo
+        }
+
+        describe("getTodayPool") {
+            it("학습 대상인 NEW/REVIEW 카드의 개수가 일일학습 최대 한도보다 많아도, 한도까지만 반환된다") {
+                val (calc, repo) = createCalculator()
+                every { repo.countNewCards(any(), any()) } returns 30
+                every { repo.countTodayReviewCards(any(), any(), any()) } returns 30
+
+                val newCardLimit = 20
+                val reviewCardLimit = 20
+                val result = calc.getTodayPool(
+                    now = baseNow,
+                    userId = 1L,
+                    timezone = kstZoneId,
+                    deckId = 1L,
+                    newCardPerDay = newCardLimit,
+                    reviewCardPerDay = reviewCardLimit,
+                    dayCutoffHour = 0,
+                )
+
+                result.newCount shouldBe newCardLimit
+                result.reviewCount shouldBe reviewCardLimit
+            }
+
+            it("NEW/REVIEW 카드 개수가 일일 학습 한도보다 적은 경우, NEW/REVIEW 카드의 개수를 반환한다") {
+                val (calc, repo) = createCalculator()
+                val existingNewCardCount = 5
+                val existingReviewCardCount = 3
+                every { repo.countNewCards(any(), any()) } returns existingNewCardCount
+                every { repo.countTodayReviewCards(any(), any(), any()) } returns existingReviewCardCount
+
+                val result = calc.getTodayPool(
+                    now = baseNow,
+                    userId = 1L,
+                    timezone = kstZoneId,
+                    deckId = 1L,
+                    newCardPerDay = 20,
+                    reviewCardPerDay = 20,
+                    dayCutoffHour = 0,
+                )
+
+                result.newCount shouldBe existingNewCardCount
+                result.reviewCount shouldBe existingReviewCardCount
+            }
+        }
+
+        describe("getTodayPool - 04시 기준 cutoff nextSessionStart 시간 계산") {
+            data class TimezoneCase(
+                val requestedAt: String,
+                val timezone: ZoneId,
+                val expectedNextSessionStart: String,
+                val label: String,
+            )
+
+            val cases = sequenceOf(
+                TimezoneCase(
+                    requestedAt = "2026-05-18T19:00:00",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 18일 19:00 요청일 경우, KST 19일 04:00이 다음 세션 시작 시간이다",
+                ),
+                TimezoneCase(
+                    requestedAt = "2026-05-19T03:59:59",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 19일 03:59:59 요청(컷오프 1초 직전)일 경우, KST 19일 04:00이 다음 세션 시작 시간이다",
+                ),
+                TimezoneCase(
+                    requestedAt = "2026-05-19T04:00:00",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-20T04:00:00",
+                    label = "KST 19일 04:00 요청(컷오프 정각)일 경우, KST 20일 04:00이 다음 세션 시작 시간이다",
+                ),
+                TimezoneCase(
+                    requestedAt = "2026-05-19T04:00:01",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-20T04:00:00",
+                    label = "KST 19일 04:00:01 요청(컷오프 1초 직후)일 경우, KST 20일 04:00이 다음 세션 시작 시간이다",
+                ),
+                TimezoneCase(
+                    requestedAt = "2026-05-18T23:59:59",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 18일 23:59:59 요청일 경우, KST 19일 04:00이 다음 세션 시작 시간이다(자정이 아닌 cutoff 기준 세션 분기)",
+                ),
+                TimezoneCase(
+                    requestedAt = "2026-05-19T00:00:01",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 19일 00:00:01 요청일 경우, KST 19일 04:00이 다음 세션 시작 시간이다(자정이 아닌 cutoff 기준 세션 분기)",
+                ),
+            )
+
+            withData(
+                nameFn = { it.label },
+                cases,
+            ) { case ->
+                val (calc, repo) = createCalculator()
+                every { repo.countTodayReviewCards(any(), any(), any()) } returns 0
+
+                calc.getTodayPool(
+                    now = LocalDateTime.parse(case.requestedAt).atZone(case.timezone).toInstant(),
+                    userId = 1L,
+                    timezone = case.timezone,
+                    deckId = 1L,
+                    newCardPerDay = 0,
+                    reviewCardPerDay = 0,
+                    dayCutoffHour = 4, // 해당 timezone의 04:00 cutoff
+                )
+
+                verify(exactly = 1) {
+                    repo.countTodayReviewCards(
+                        userId = 1L,
+                        deckId = 1L,
+                        nextSessionStart = LocalDateTime.parse(case.expectedNextSessionStart).atZone(case.timezone).toInstant(),
+                    )
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
@@ -1,0 +1,325 @@
+package com.whatever.caro.study.internal
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudySessionStatus
+import com.whatever.caro.study.StudyType
+import com.whatever.caro.study.TodaySummaryState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import com.whatever.caro.study.internal.studysession.StudySession
+import com.whatever.caro.study.internal.studysession.StudySessionRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.modulith.test.ApplicationModuleTest
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class)
+class StudyServiceTest(
+    private val studyService: StudyService,
+    private val studySessionRepository: StudySessionRepository,
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) : DescribeSpec({
+
+    val kstZoneId = ZoneId.of("Asia/Seoul")
+    val dayCutoffHour = 4
+
+    val baseNow: Instant = LocalDateTime.parse("2026-05-19T10:00:00").atZone(kstZoneId).toInstant()
+    val today: LocalDate = LocalDate.parse("2026-05-19")
+    val yesterday: LocalDate = LocalDate.parse("2026-05-18")
+
+    afterEach {
+        studySessionRepository.deleteAllInBatch()
+        cardLearningStateRepository.deleteAllInBatch()
+    }
+
+    fun createSession(
+        userId: Long = USER_ID,
+        deckId: Long = DECK_ID,
+        status: StudySessionStatus = StudySessionStatus.ACTIVE,
+        sessionDate: LocalDate = today,
+        startedAt: Instant = baseNow,
+        newStudied: Int = 0,
+        reviewStudied: Int = 0,
+        estimatedTotal: Int = 20,
+    ): StudySession =
+        studySessionRepository.save(
+            StudySession(
+                userId = userId,
+                deckId = deckId,
+                status = status,
+                studyType = StudyType.DAILY,
+                startedAt = startedAt,
+                timezone = kstZoneId,
+                dayCutoffHour = dayCutoffHour,
+                sessionDate = sessionDate,
+                deckPresetIdSnapshot = 1L,
+                newCardsStudied = newStudied,
+                reviewCardsStudied = reviewStudied,
+                estimatedTotal = estimatedTotal,
+            ),
+        )
+
+    fun createCls(
+        cardId: Long,
+        userId: Long = USER_ID,
+        deckId: Long = DECK_ID,
+        status: CardLearningStatus = CardLearningStatus.REVIEW,
+        totalReviews: Int = 0,
+        consecutiveAgainCount: Int = 0,
+    ): CardLearningState =
+        cardLearningStateRepository.save(
+            CardLearningState(
+                cardId = cardId,
+                deckId = deckId,
+                userId = userId,
+                status = status,
+                totalReviews = totalReviews,
+                consecutiveAgainCount = consecutiveAgainCount,
+            ),
+        )
+
+    describe("getTodaySummary") {
+
+        it("일일학습 세션이 없으면 null을 반환한다") {
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result shouldBe null
+        }
+
+        it("ACTIVE 상태인 오늘 세션이면 IN_PROGRESS인 dto를 반환한다") {
+            val session = createSession(
+                status = StudySessionStatus.ACTIVE,
+                sessionDate = today,
+                newStudied = 3,
+                reviewStudied = 5,
+                estimatedTotal = 20,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result.shouldNotBeNull()
+            result.sessionId shouldBe session.id
+            result.state shouldBe TodaySummaryState.IN_PROGRESS
+            result.studiedCardCount shouldBe 8
+            result.totalCardCount shouldBe 20
+        }
+
+        it("ACTIVE 상태이지만 오늘이 아닌 세션이면 STOPPED으로 변경되고 null을 반환한다") {
+            val staleSession = createSession(
+                status = StudySessionStatus.ACTIVE,
+                sessionDate = yesterday,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result shouldBe null
+
+            val stoppedSession = studySessionRepository.findByIdOrNull(staleSession.id)
+            stoppedSession.shouldNotBeNull()
+            stoppedSession.status shouldBe StudySessionStatus.STOPPED
+        }
+
+        it("COMPLETED 상태인 오늘 세션이면 COMPLETED dto를 매핑해 반환한다") {
+            val session = createSession(
+                status = StudySessionStatus.COMPLETED,
+                sessionDate = today,
+                newStudied = 10,
+                reviewStudied = 10,
+                estimatedTotal = 20,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result.shouldNotBeNull()
+            result.sessionId shouldBe session.id
+            result.state shouldBe TodaySummaryState.COMPLETED
+            result.studiedCardCount shouldBe 20
+            result.totalCardCount shouldBe 20
+            result.studiedCardCount shouldBeEqual result.totalCardCount
+        }
+
+        it("COMPLETED 상태지만 오늘이 아닌 세션이면 null을 반환하고 status는 변경되지 않는다") {
+            val session = createSession(
+                status = StudySessionStatus.COMPLETED,
+                sessionDate = yesterday,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result shouldBe null
+
+            val completedSession = studySessionRepository.findByIdOrNull(session.id)
+            completedSession.shouldNotBeNull()
+            completedSession.status shouldBe StudySessionStatus.COMPLETED
+        }
+
+        it("STOPPED 상태지만 오늘 세션이라면 null을 반환한다") {
+            // 정상 flow에서는 나올 수 없음
+            val session = createSession(
+                status = StudySessionStatus.STOPPED,
+                sessionDate = today,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+            result shouldBe null
+
+            val stoppedSession = studySessionRepository.findByIdOrNull(session.id)
+            stoppedSession.shouldNotBeNull()
+            stoppedSession.status shouldBe StudySessionStatus.STOPPED
+        }
+
+        it("여러 세션이 있다면 가장 최신 세션을 기준으로 응답한다") {
+            // 어제 세션
+            createSession(
+                status = StudySessionStatus.COMPLETED,
+                sessionDate = yesterday,
+                startedAt = yesterday.atTime(dayCutoffHour, 0).atZone(kstZoneId).toInstant(),
+            )
+            // 오늘 세션
+            val latestSession = createSession(
+                status = StudySessionStatus.ACTIVE,
+                sessionDate = today,
+                startedAt = baseNow,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result.shouldNotBeNull()
+            result.sessionId shouldBe latestSession.id
+            result.state shouldBe TodaySummaryState.IN_PROGRESS
+        }
+
+        it("다른 유저나, 덱에 속한 세션은 결과에 영향을 주지 않는다") {
+            createSession( // 다른 user의 오늘 ACTIVE 세션
+                userId = 2L,
+                deckId = DECK_ID,
+                status = StudySessionStatus.ACTIVE,
+                sessionDate = today,
+            )
+            createSession( // 다른 deck의 오늘 ACTIVE 세션
+                userId = USER_ID,
+                deckId = 2L,
+                status = StudySessionStatus.ACTIVE,
+                sessionDate = today,
+            )
+
+            val result = studyService.getTodaySummary(
+                now = baseNow,
+                userId = USER_ID,
+                deckId = DECK_ID,
+            )
+
+            result shouldBe null
+        }
+    }
+
+    describe("getLearningStates") {
+
+        it("매칭되는 카드는 cardId 기준 맵으로 매핑되고, 매칭되지 않는 요소는 무시한다") {
+            val states = listOf(
+                createCls(
+                    cardId = 1L,
+                    totalReviews = 3,
+                    consecutiveAgainCount = 1,
+                ),
+                createCls(
+                    cardId = 2L,
+                    totalReviews = 0,
+                    consecutiveAgainCount = 0,
+                ),
+            )
+
+            val cardIds = states.map { it.cardId }
+            val result = studyService.getLearningStates(
+                userId = USER_ID,
+                cardIds = cardIds + 3L,
+            )
+
+            result.keys.shouldContainExactlyInAnyOrder(cardIds)
+
+            val firstId = cardIds.first()
+            result[firstId]?.totalReviews shouldBe 3
+            result[firstId]?.consecutiveAgainCount shouldBe 1
+
+            val secondId = cardIds.last()
+            result[secondId]?.totalReviews shouldBe 0
+        }
+
+        it("내 카드 학습 상태만 조회할 수 있다") {
+            val states = listOf(
+                createCls(
+                    cardId = 1L,
+                    userId = USER_ID,
+                ),
+                createCls(
+                    cardId = 2L,
+                    userId = 2L,
+                ),
+            )
+
+            val result = studyService.getLearningStates(
+                userId = states.first().userId,
+                cardIds = states.map { it.cardId },
+            )
+
+            result.keys.shouldContainExactlyInAnyOrder(setOf(states.first().cardId))
+        }
+
+        it("조회할 card Id가 비었다면 nul을 반환한다") {
+            createCls(
+                cardId = 1L,
+            )
+
+            val result = studyService.getLearningStates(
+                userId = USER_ID,
+                cardIds = emptyList(),
+            )
+
+            result.shouldBeEmpty()
+        }
+    }
+}) {
+    companion object {
+        private const val USER_ID = 1L
+        private const val DECK_ID = 1L
+    }
+}

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
@@ -91,14 +91,14 @@ class StudyServiceTest(
 
     describe("getTodaySummary") {
 
-        it("일일학습 세션이 없으면 null을 반환한다") {
+        it("일일학습 세션이 없으면 NOT_STARTED dto를 반환한다") {
             val result = studyService.getTodaySummary(
                 now = baseNow,
                 userId = USER_ID,
                 deckId = DECK_ID,
             )
 
-            result shouldBe null
+            result.state shouldBe TodaySummaryState.NOT_STARTED
         }
 
         it("ACTIVE 상태인 오늘 세션이면 IN_PROGRESS인 dto를 반환한다") {
@@ -123,7 +123,7 @@ class StudyServiceTest(
             result.totalCardCount shouldBe 20
         }
 
-        it("ACTIVE 상태이지만 오늘이 아닌 세션이면 STOPPED으로 변경되고 null을 반환한다") {
+        it("ACTIVE 상태이지만 오늘이 아닌 세션이면 STOPPED으로 변경되고, NOT_STARTED dto를 반환한다") {
             val staleSession = createSession(
                 status = StudySessionStatus.ACTIVE,
                 sessionDate = yesterday,
@@ -135,7 +135,7 @@ class StudyServiceTest(
                 deckId = DECK_ID,
             )
 
-            result shouldBe null
+            result.state shouldBe TodaySummaryState.NOT_STARTED
 
             val stoppedSession = studySessionRepository.findByIdOrNull(staleSession.id)
             stoppedSession.shouldNotBeNull()
@@ -165,7 +165,7 @@ class StudyServiceTest(
             result.studiedCardCount shouldBeEqual result.totalCardCount
         }
 
-        it("COMPLETED 상태지만 오늘이 아닌 세션이면 null을 반환하고 status는 변경되지 않는다") {
+        it("COMPLETED 상태지만 오늘이 아닌 세션이면 NOT_STARTED dto를 반환하고 status는 변경되지 않는다") {
             val session = createSession(
                 status = StudySessionStatus.COMPLETED,
                 sessionDate = yesterday,
@@ -177,14 +177,14 @@ class StudyServiceTest(
                 deckId = DECK_ID,
             )
 
-            result shouldBe null
+            result.state shouldBe TodaySummaryState.NOT_STARTED
 
             val completedSession = studySessionRepository.findByIdOrNull(session.id)
             completedSession.shouldNotBeNull()
             completedSession.status shouldBe StudySessionStatus.COMPLETED
         }
 
-        it("STOPPED 상태지만 오늘 세션이라면 null을 반환한다") {
+        it("STOPPED 상태지만 오늘 세션이라면 NOT_STARTED dto를 반환한다") {
             // 정상 flow에서는 나올 수 없음
             val session = createSession(
                 status = StudySessionStatus.STOPPED,
@@ -196,7 +196,7 @@ class StudyServiceTest(
                 userId = USER_ID,
                 deckId = DECK_ID,
             )
-            result shouldBe null
+            result.state shouldBe TodaySummaryState.NOT_STARTED
 
             val stoppedSession = studySessionRepository.findByIdOrNull(session.id)
             stoppedSession.shouldNotBeNull()
@@ -248,7 +248,7 @@ class StudyServiceTest(
                 deckId = DECK_ID,
             )
 
-            result shouldBe null
+            result.state shouldBe TodaySummaryState.NOT_STARTED
         }
     }
 

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -1,0 +1,373 @@
+package com.whatever.caro.study.internal.cardlearningstate
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.study.CardLearningStatus
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.context.annotation.Import
+import org.springframework.modulith.test.ApplicationModuleTest
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class)
+class CardLearningStateRepositoryTest(
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) : DescribeSpec({
+
+    val kstZoneId = ZoneId.of("Asia/Seoul")
+
+    // 기준: nextSessionStart = KST 2026-05-19 04:00:00 = UTC 2026-05-18 19:00:00
+    val nextSessionStart = LocalDateTime.parse("2026-05-19T04:00:00").atZone(kstZoneId).toInstant()
+    val beforeCutoff = LocalDateTime.parse("2026-05-19T03:59:59").atZone(kstZoneId).toInstant()
+    val afterCutoff = LocalDateTime.parse("2026-05-19T04:00:01").atZone(kstZoneId).toInstant()
+
+    afterEach {
+        cardLearningStateRepository.deleteAllInBatch()
+    }
+
+    fun createCls(
+        cardId: Long,
+        deckId: Long = 1L,
+        userId: Long = 1L,
+        status: CardLearningStatus = CardLearningStatus.REVIEW,
+        nextReviewAt: Instant? = null,
+    ): CardLearningState =
+        cardLearningStateRepository.save(
+            CardLearningState(
+                cardId = cardId,
+                deckId = deckId,
+                userId = userId,
+                status = status,
+                nextReviewAt = nextReviewAt,
+            ),
+        )
+
+    describe("countTodayReviewCards") {
+        it("다음 리뷰일이 오늘 세션이 끝나기 직전(nextSessionStart -1초)인 카드는 포함된다") {
+            val cls = createCls(
+                cardId = 1L,
+                nextReviewAt = nextSessionStart.minusSeconds(1),
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 1
+        }
+
+        it("다음 리뷰일이 오늘 세션에 포함되지 않은(nextSessionStart와 동일한) 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                nextReviewAt = nextSessionStart,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+
+        it("다음 리뷰일이 없는 카드는 제외된다") {
+            // status가 REVIEW이며, nextReviewAt이 null인 카드는 존재할 수 없지만 테스트를 위해 임의 생성
+            val cls = createCls(
+                cardId = 1L,
+                nextReviewAt = null,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+
+        it("요청 userId와 다른 userId의 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                userId = 1L,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = 2L, // other user
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+
+        it("요청 deckId와 다른 deckId의 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                deckId = 1L,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = 2L, // other deck
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+
+        it("매칭 조건을 만족하는 여러 카드는 합산된 카운트로 반환된다") {
+            createCls(
+                cardId = 1L,
+                nextReviewAt = beforeCutoff,
+            )
+            createCls(
+                cardId = 2L,
+                nextReviewAt = beforeCutoff,
+            )
+            val cls = createCls(
+                cardId = 3L,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 3
+        }
+
+        it("학습 대상 카드가 없을 경우 0을 반환한다") {
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = 1L,
+                deckId = 1L,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+
+        it("status=SUSPENDED 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                status = CardLearningStatus.SUSPENDED,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+
+        it("status=NEW 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countTodayReviewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+                nextSessionStart = nextSessionStart,
+            )
+
+            count shouldBe 0
+        }
+    }
+
+    describe("findAllByUserIdAndCardIdIn") {
+        it("요청한 cardIds 전부가 존재할 때 모든 매칭 카드를 반환한다") {
+            val clsList = listOf(
+                createCls(cardId = 1L, nextReviewAt = beforeCutoff),
+                createCls(cardId = 2L, nextReviewAt = beforeCutoff),
+                createCls(cardId = 3L, nextReviewAt = beforeCutoff),
+            )
+            val cardIds = clsList.map { it.cardId }
+
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+                userId = clsList.first().userId,
+                cardIds = cardIds,
+            )
+
+            result.map { it.cardId }.shouldContainExactlyInAnyOrder(cardIds)
+        }
+
+        it("요청 userId와 다른 userId의 카드는 결과에서 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                userId = 2L,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+                userId = 1L,
+                cardIds = listOf(cls.cardId),
+            )
+
+            result.size shouldBe 0
+        }
+
+        it("빈 cardIds 컬렉션은 빈 결과를 반환한다") {
+            val cls = createCls(
+                cardId = 1L,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+                userId = cls.userId,
+                cardIds = emptyList(),
+            )
+
+            result.size shouldBe 0
+        }
+
+        it("요청한 cardIds 중 존재하는 카드만 부분 매칭으로 반환된다 (derived query IN 절 가드)") {
+            val cls = createCls(
+                cardId = 1L,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+                userId = cls.userId,
+                cardIds = listOf(cls.cardId, 2L),
+            )
+
+            result.map { it.cardId }.shouldContainExactlyInAnyOrder(listOf(cls.cardId))
+        }
+    }
+
+    describe("countNewCards") {
+        it("status=NEW 카드는 포함된다") {
+            val cls = createCls(
+                cardId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = null,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+            )
+
+            count shouldBe 1
+        }
+
+        it("status=REVIEW 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                status = CardLearningStatus.REVIEW,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+            )
+
+            count shouldBe 0
+        }
+
+        it("status=SUSPENDED 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                status = CardLearningStatus.SUSPENDED,
+                nextReviewAt = null,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+            )
+
+            count shouldBe 0
+        }
+
+        it("요청 userId와 다른 userId의 NEW 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                userId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = null,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = 2L, // other user
+                deckId = cls.deckId,
+            )
+
+            count shouldBe 0
+        }
+
+        it("요청 deckId와 다른 deckId의 NEW 카드는 제외된다") {
+            val cls = createCls(
+                cardId = 1L,
+                deckId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = null,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = cls.userId,
+                deckId = 2L, // other deck
+            )
+
+            count shouldBe 0
+        }
+
+        it("매칭 조건을 만족하는 여러 NEW 카드는 합산해 반환된다") {
+            createCls(
+                cardId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = null,
+            )
+            createCls(
+                cardId = 2L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = null,
+            )
+            val cls = createCls(
+                cardId = 3L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = null,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+            )
+
+            count shouldBe 3
+        }
+
+        it("status=NEW 카드는 nextReviewAt 값과 무관하게 카운트에 포함된다") {
+            // 정상적인 데이터라면 NEW 카드는 nextReviewAt이 존재하지 않음, 그러나 존재하더라도 무시
+            val cls = createCls(
+                cardId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val count = cardLearningStateRepository.countNewCards(
+                userId = cls.userId,
+                deckId = cls.deckId,
+            )
+
+            count shouldBe 1
+        }
+    }
+})

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
@@ -1,0 +1,61 @@
+package com.whatever.caro.study.internal.studysession
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.study.StudySessionStatus
+import com.whatever.caro.study.StudyType
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.context.annotation.Import
+import org.springframework.modulith.test.ApplicationModuleTest
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class)
+class StudySessionRepositoryTest(
+    private val studySessionRepository: StudySessionRepository,
+) : DescribeSpec({
+    val kstZoneId = ZoneId.of("Asia/Seoul")
+    val now: Instant = Instant.parse("2026-05-19T01:00:00Z")
+    val today: LocalDate = LocalDate.parse("2026-05-19")
+
+    afterEach { studySessionRepository.deleteAllInBatch() }
+
+    fun saveSession(
+        status: StudySessionStatus = StudySessionStatus.ACTIVE,
+    ): StudySession =
+        studySessionRepository.save(
+            StudySession(
+                userId = 1L,
+                deckId = 1L,
+                status = status,
+                studyType = StudyType.DAILY,
+                startedAt = now,
+                timezone = kstZoneId,
+                dayCutoffHour = 4,
+                sessionDate = today,
+                deckPresetIdSnapshot = 1L,
+            ),
+        )
+
+    describe("setStoppedIfActive - 멱등성 가드 (통합 미커버)") {
+        it("이미 STOPPED인 row를 재호출하면 effectedRow=0이고 status는 STOPPED로 유지된다") {
+            val session = saveSession(status = StudySessionStatus.STOPPED)
+
+            val affected = studySessionRepository.setStoppedIfActive(session.id)
+
+            affected shouldBe 0
+            studySessionRepository.findById(session.id).orElseThrow().status shouldBe StudySessionStatus.STOPPED
+        }
+
+        it("COMPLETED row를 호출하면 effectedRow=0이고 status는 COMPLETED로 유지된다") {
+            val session = saveSession(status = StudySessionStatus.COMPLETED)
+
+            val affected = studySessionRepository.setStoppedIfActive(session.id)
+
+            affected shouldBe 0
+            studySessionRepository.findById(session.id).orElseThrow().status shouldBe StudySessionStatus.COMPLETED
+        }
+    }
+})

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
@@ -1,0 +1,74 @@
+package com.whatever.caro.study.internal.studysession
+
+import com.whatever.caro.study.StudySessionStatus
+import com.whatever.caro.study.StudyType
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class StudySessionTest :
+    DescribeSpec({
+        val kstZoneId = ZoneId.of("Asia/Seoul")
+        val dayCutoffHour = 4
+        // 산식: isTodaySession(now) = (sessionDate == now.atZone(KST).minusHours(4).toLocalDate())
+        // sessionDate=2026-05-18 기준으로 "now가 cutoff 04:00 직전인지" 경계 검증
+        val sessionDate: LocalDate = LocalDate.parse("2026-05-18")
+
+        fun createSession(): StudySession =
+            StudySession(
+                userId = 1L,
+                deckId = 1L,
+                status = StudySessionStatus.ACTIVE,
+                studyType = StudyType.DAILY,
+                startedAt = Instant.parse("2026-05-18T00:00:00Z"),
+                timezone = kstZoneId,
+                dayCutoffHour = dayCutoffHour,
+                sessionDate = sessionDate,
+                deckPresetIdSnapshot = 1L,
+            )
+
+        describe("isTodaySession - KST cutoff=04:00 경계 (sessionDate=2026-05-18 기준)") {
+            data class Case(
+                val nowKst: String,
+                val expected: Boolean,
+                val label: String,
+            )
+
+            withData(
+                nameFn = { it.label },
+                // KST 03:59:59 → minusHours(4) = 05-18T23:59:59 → date=05-18 → sessionDate와 같음 → true
+                Case(
+                    "2026-05-19T03:59:59",
+                    true,
+                    "KST 2026-05-19 03:59:59 (cutoff 1초 전) → 여전히 전일 sessionDate=2026-05-18 (true)",
+                ),
+                // KST 04:00:00 → minusHours(4) = 05-19T00:00:00 → date=05-19 → 다른 sessionDate → false
+                Case(
+                    "2026-05-19T04:00:00",
+                    false,
+                    "KST 2026-05-19 04:00:00 (cutoff 정각) → 새 sessionDate=2026-05-19로 전환 (false)",
+                ),
+                // KST 04:00:01 → minusHours(4) = 05-19T00:00:01 → date=05-19 → false
+                Case(
+                    "2026-05-19T04:00:01",
+                    false,
+                    "KST 2026-05-19 04:00:01 (cutoff 1초 후) → 새 sessionDate=2026-05-19 (false)",
+                ),
+                // KST 자정 직후 00:00:01 → minusHours(4) = 05-18T20:00:01 → date=05-18 → true (자정이 분기 아님)
+                Case(
+                    "2026-05-19T00:00:01",
+                    true,
+                    "KST 2026-05-19 00:00:01 (자정 직후, cutoff 이전) → 전일 sessionDate=2026-05-18 유지 (true) — 자정이 아닌 cutoff가 분기 기준",
+                ),
+            ) { case ->
+                val now = LocalDateTime.parse(case.nowKst).atZone(kstZoneId).toInstant()
+                val session = createSession()
+
+                session.isTodaySession(now) shouldBe case.expected
+            }
+        }
+    })


### PR DESCRIPTION
## 📌 Related Issue
Closes #41 

## 📝 Changes
### Schema 수정
- `V4__card_learning_state_add_deck_id.sql`
  - `card_learning_states.deck_id` 컬럼 추가

### Study 모듈 (deck 상세 화면에 필요한 read 기능 구현)
- `StudyApi` 공개 인터페이스 추가
  - `getTodaySummary(now, userId, deckId)`
    - 최신 세션 기반 IN_PROGRESS/COMPLETED만 판정. BEFORE/REST 후보는 `null` 반환
  - `getLearningStates(userId, cardIds)`
    - 카드별 학습 상태 정보 반환
- `StudyService` 구현

### 인프라
- JVM `user.timezone=UTC`, Dockerfile TZ 옵션 추가
  - Entity의 LocalDate를 사용하는 프로퍼티가 sql로 작성될 때 jvm timezone을 기반으로 자동 변환되는 문제 방지
- `bff` 모듈 추가
  - 구현은 card 관련 pr 병합 후, 별도로 pr 작성 에정

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
