### PR TITLE
[Feat] 닉네임 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/user/UserApi.kt
+++ b/src/main/kotlin/com/whatever/caro/user/UserApi.kt
@@ -22,11 +22,6 @@ interface UserApi {
         isTermsAgreed: Boolean,
     ): UserInfo
 
-    fun updateNickname(
-        userId: Long,
-        nickname: String,
-    ): UserInfo
-
     fun isNicknameAvailable(
         nickname: String,
     ): Boolean

--- a/src/main/kotlin/com/whatever/caro/user/UserApi.kt
+++ b/src/main/kotlin/com/whatever/caro/user/UserApi.kt
@@ -22,6 +22,11 @@ interface UserApi {
         isTermsAgreed: Boolean,
     ): UserInfo
 
+    fun updateNickname(
+        userId: Long,
+        nickname: String,
+    ): UserInfo
+
     fun isNicknameAvailable(
         nickname: String,
     ): Boolean

--- a/src/main/kotlin/com/whatever/caro/user/exception/InvalidNicknameException.kt
+++ b/src/main/kotlin/com/whatever/caro/user/exception/InvalidNicknameException.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.user.exception
+
+import com.whatever.caro.common.exception.BusinessException
+
+class InvalidNicknameException(
+    message: String,
+) : BusinessException(UserErrorCode.INVALID_NICKNAME, message = message)

--- a/src/main/kotlin/com/whatever/caro/user/exception/UserErrorCode.kt
+++ b/src/main/kotlin/com/whatever/caro/user/exception/UserErrorCode.kt
@@ -12,4 +12,5 @@ enum class UserErrorCode(
     NOT_FOUND("U001", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다", "error.user.not_found"),
     ALREADY_COMPLETED("U002", HttpStatus.CONFLICT, "이미 회원가입이 완료된 사용자입니다", "error.user.already_completed"),
     NICKNAME_DUPLICATED("U003", HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다", "error.user.nickname_duplicated"),
+    INVALID_NICKNAME("U004", HttpStatus.BAD_REQUEST, "유효하지 않은 닉네임입니다", "error.user.invalid_nickname"),
 }

--- a/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
@@ -76,7 +76,7 @@ class UserService(
         require(isTermsAgreed) { "약관 동의가 필요합니다" }
 
         val user = userRepository.findByIdOrNull(userId)
-            ?: throw UserNotFoundException("User not found: $userId")
+            ?: throw UserNotFoundException("사용자를 찾을 수 없습니다: $userId")
 
         if (user.status == UserStatus.ACTIVE) {
             throw AlreadyCompletedException("이미 가입이 완료된 사용자입니다")
@@ -91,6 +91,26 @@ class UserService(
             this.isTermsAgreed = true
             this.status = UserStatus.ACTIVE
         }
+        return user.toInfo()
+    }
+
+    @Transactional
+    override fun updateNickname(
+        userId: Long,
+        nickname: String,
+    ): UserInfo {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw UserNotFoundException("사용자를 찾을 수 없습니다: $userId")
+
+        if (user.nickname == nickname) {
+            return user.toInfo()
+        }
+
+        if (!isNicknameAvailable(nickname)) {
+            throw NicknameDuplicatedException("이미 사용 중인 닉네임입니다: $nickname")
+        }
+
+        user.nickname = nickname
         return user.toInfo()
     }
 

--- a/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
@@ -95,7 +95,7 @@ class UserService(
     }
 
     @Transactional
-    override fun updateNickname(
+    fun updateNickname(
         userId: Long,
         nickname: String,
     ): UserInfo {

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
@@ -2,15 +2,22 @@ package com.whatever.caro.user.internal.web
 
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.user.UserApi
+import com.whatever.caro.user.internal.web.request.UpdateNicknameRequest
 import com.whatever.caro.user.internal.web.response.NicknameCheckResponse
+import com.whatever.caro.user.internal.web.response.UpdateNicknameResponse
+import com.whatever.caro.user.internal.web.response.toUpdateNicknameResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -30,10 +37,24 @@ class UserController(
     fun checkNicknameAvailability(
         @PathVariable
         @NotBlank(message = "Nickname is required")
-        @Size(max = 50, message = "Nickname must be 50 characters or fewer")
+        @Size(min = 1, max = 50, message = "Nickname must be 1-50 characters")
         nickname: String,
     ): ResponseEntity<ApiResponse<NicknameCheckResponse>> {
         val available = userApi.isNicknameAvailable(nickname)
         return ResponseEntity.ok(ApiResponse.ok(NicknameCheckResponse(nickname, available)))
+    }
+
+    @Operation(
+        summary = "닉네임 변경",
+        description = "현재 로그인한 사용자의 닉네임을 변경한다.",
+    )
+    @PatchMapping("/me/nickname")
+    fun updateNickname(
+        @Valid @RequestBody request: UpdateNicknameRequest,
+        @AuthenticationPrincipal(expression = "userId")
+        userId: Long,
+    ): ResponseEntity<ApiResponse<UpdateNicknameResponse>> {
+        val updated = userApi.updateNickname(userId = userId, nickname = request.nickname)
+        return ResponseEntity.ok(ApiResponse.ok(updated.toUpdateNicknameResponse()))
     }
 }

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
@@ -2,6 +2,7 @@ package com.whatever.caro.user.internal.web
 
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.user.UserApi
+import com.whatever.caro.user.internal.UserService
 import com.whatever.caro.user.internal.web.request.UpdateNicknameRequest
 import com.whatever.caro.user.internal.web.response.NicknameCheckResponse
 import com.whatever.caro.user.internal.web.response.UpdateNicknameResponse
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/users")
 class UserController(
     private val userApi: UserApi,
+    private val userService: UserService,
 ) {
 
     @Operation(
@@ -54,7 +56,7 @@ class UserController(
         @AuthenticationPrincipal(expression = "userId")
         userId: Long,
     ): ResponseEntity<ApiResponse<UpdateNicknameResponse>> {
-        val updated = userApi.updateNickname(userId = userId, nickname = request.nickname)
+        val updated = userService.updateNickname(userId = userId, nickname = request.nickname)
         return ResponseEntity.ok(ApiResponse.ok(updated.toUpdateNicknameResponse()))
     }
 }

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/request/UpdateNicknameRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/request/UpdateNicknameRequest.kt
@@ -1,0 +1,13 @@
+package com.whatever.caro.user.internal.web.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(name = "UpdateNicknameRequest", description = "닉네임 변경 요청")
+data class UpdateNicknameRequest(
+    @field:NotBlank(message = "Nickname is required")
+    @field:Size(min = 1, max = 50, message = "Nickname must be 1-50 characters")
+    @field:Schema(description = "변경할 닉네임", example = "다정한 고슴도치", required = true)
+    val nickname: String,
+)

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/response/UpdateNicknameResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/response/UpdateNicknameResponse.kt
@@ -1,0 +1,18 @@
+package com.whatever.caro.user.internal.web.response
+
+import com.whatever.caro.user.UserInfo
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "UpdateNicknameResponse", description = "닉네임 변경 응답")
+data class UpdateNicknameResponse(
+    @field:Schema(description = "사용자 ID", example = "1")
+    val userId: Long,
+    @field:Schema(description = "변경된 닉네임", example = "다정한 고슴도치")
+    val nickname: String,
+)
+
+fun UserInfo.toUpdateNicknameResponse(): UpdateNicknameResponse =
+    UpdateNicknameResponse(
+        userId = id,
+        nickname = nickname,
+    )

--- a/src/test/kotlin/com/whatever/caro/user/internal/UserServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/user/internal/UserServiceTest.kt
@@ -153,6 +153,85 @@ class UserServiceTest(
         }
     }
 
+    describe("updateNickname") {
+        it("정상적으로 닉네임을 변경한다") {
+            val user = createActiveUser(nickname = "oldNick")
+
+            val result = userService.updateNickname(
+                userId = user.id,
+                nickname = "newNick",
+            )
+
+            result.id shouldBe user.id
+            result.nickname shouldBe "newNick"
+            userRepository.findByIdOrNull(user.id)!!.nickname shouldBe "newNick"
+        }
+
+        it("존재하지 않는 userId이면 UserNotFoundException을 던진다") {
+            val invalidUserId = 0L
+            userRepository.findByIdOrNull(invalidUserId) shouldBe null
+
+            shouldThrow<UserNotFoundException> {
+                userService.updateNickname(
+                    userId = invalidUserId,
+                    nickname = "newNick",
+                )
+            }
+        }
+
+        it("이미 다른 유저가 사용 중인 닉네임이면 NicknameDuplicatedException을 던진다") {
+            val takenNickname = "takenNick"
+            createActiveUser(nickname = takenNickname)
+            val target = createActiveUser(nickname = "myNick")
+
+            shouldThrow<NicknameDuplicatedException> {
+                userService.updateNickname(
+                    userId = target.id,
+                    nickname = takenNickname,
+                )
+            }
+        }
+
+        it("유효하지 않은 닉네임 형식이면 예외를 던진다") {
+            val user = createActiveUser(nickname = "myNick")
+
+            shouldThrow<NicknameDuplicatedException> {
+                userService.updateNickname(
+                    userId = user.id,
+                    nickname = "??invalid@#",
+                )
+            }
+        }
+
+        it("현재 닉네임과 동일하면 변경 없이 현재 정보를 반환한다") {
+            val sameNickname = "sameNick"
+            val user = createActiveUser(nickname = sameNickname)
+
+            val result = userService.updateNickname(
+                userId = user.id,
+                nickname = sameNickname,
+            )
+
+            result.nickname shouldBe sameNickname
+            userRepository.findByIdOrNull(user.id)!!.nickname shouldBe sameNickname
+        }
+
+        it("다른 유저가 soft-delete된 닉네임은 사용 가능하다") {
+            val recycledNickname = "recycledNick"
+            val deletedUser = createActiveUser(nickname = recycledNickname)
+            deletedUser.softDelete(Instant.now())
+            userRepository.save(deletedUser)
+
+            val target = createActiveUser(nickname = "myNick")
+            val result = userService.updateNickname(
+                userId = target.id,
+                nickname = recycledNickname,
+            )
+
+            result.nickname shouldBe recycledNickname
+        }
+    }
+
     describe("findById") {
         it("존재하는 유저를 반환한다") {
             val user = createSuspendedUser("TestUser")


### PR DESCRIPTION
## 📌 Related Issue
#44

## 📝 Changes
닉네임 변경 API를 만들었어요

그런데, 작성하다보니 기존에 isNicknameAvailable 케이스에 중복 or invalid에 대한 에러를 isNicknameAvailable(nickname) 에서 체크해서 둘다 DuplicatedException을 주고 있던데, InvalidException을 만들긴 했지만 일관성 유지를 위해 통일은 했습니다.
InvalidException을 만들긴 했는데 사용은 안했어요

함수 사용을 제거하고 둘다 바꾸는게 나을까요~

추가로 url은 캐싱될 수도 있을 것 같아 변경은 url이 아닌 파라미터로 받았어요


## ✅ Checklist
- [ ] 테스트 완료
- [ ] 리뷰 준비 완료

## 📋 Additional Notes(Optional)