### PR TITLE
[Feat] 카드 삭제 시 학습 세션 목표 조정, LearningState 정리

### DIFF
--- a/src/main/kotlin/com/whatever/caro/bff/ModuleMetadata.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/ModuleMetadata.kt
@@ -6,6 +6,6 @@ import org.springframework.modulith.PackageInfo
 @PackageInfo
 @ApplicationModule(
     displayName = "BackendForFrontend",
-    allowedDependencies = ["common", "study", "card :: card", "auth"],
+    allowedDependencies = ["common", "study", "card :: card", "card :: deck", "auth"],
 )
 class ModuleMetadata

--- a/src/main/kotlin/com/whatever/caro/bff/internal/CardLearningStateBadge.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/CardLearningStateBadge.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.bff.internal
+
+enum class CardLearningStateBadge {
+    NEW,
+    REVIEW,
+    HARD,
+}

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
@@ -1,0 +1,70 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.card.api.card.CardApi
+import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckPresetApi
+import com.whatever.caro.study.CardLearningStateDto
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudyApi
+import org.springframework.stereotype.Service
+
+@Service
+class DeckBFFService(
+    private val cardApi: CardApi,
+    private val studyApi: StudyApi,
+    private val deckPresetApi: DeckPresetApi,
+) {
+    fun getCardsWithLearningState(
+        userId: Long,
+        deckId: Long,
+    ): List<DeckCardItem> {
+        val cards = cardApi.getCardContentsByDeck(
+            userId = userId,
+            deckId = deckId,
+        ).takeIf { it.isNotEmpty() } ?: return emptyList()
+
+        val learningStateByCardId = studyApi.getLearningStates(
+            userId = userId,
+            cardIds = cards.map { it.cardId },
+        )
+        val deckPreset = deckPresetApi.getLatestDeckPresetByUser(deckId, userId)
+
+        return cards.map { card ->
+            toDeckCardItem(
+                card = card,
+                state = learningStateByCardId[card.cardId],
+                hardBadgeThreshold = deckPreset.hardBadgeThreshold,
+            )
+        }
+    }
+}
+
+private fun toDeckCardItem(
+    card: CardContentDto,
+    state: CardLearningStateDto?,
+    hardBadgeThreshold: Int,
+): DeckCardItem =
+    DeckCardItem(
+        cardId = card.cardId,
+        fields = card.fields,
+
+        // state가 생성되지 않았을 경우 NEW 카드로 반환
+        badge = state?.toBadge(hardBadgeThreshold) ?: CardLearningStateBadge.NEW,
+        reviewCount = state?.totalReviews ?: 0,
+    )
+
+private fun CardLearningStateDto.toBadge(
+    hardBadgeThreshold: Int,
+): CardLearningStateBadge {
+    // SUSPENDED를 먼저 차단
+    val baseBadge = when (status) {
+        CardLearningStatus.NEW -> CardLearningStateBadge.NEW
+        CardLearningStatus.REVIEW -> CardLearningStateBadge.REVIEW
+        CardLearningStatus.SUSPENDED -> error("SUSPENDED status is not supported")
+    }
+
+    if (consecutiveAgainCount >= hardBadgeThreshold) {
+        return CardLearningStateBadge.HARD
+    }
+    return baseBadge
+}

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
@@ -2,17 +2,23 @@ package com.whatever.caro.bff.internal
 
 import com.whatever.caro.card.api.card.CardApi
 import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckApi
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.study.CardLearningStateDto
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.StudyApi
+import com.whatever.caro.study.TodayStudySessionState
+import com.whatever.caro.study.TodaySummaryState
 import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.ZoneId
 
 @Service
 class DeckBFFService(
     private val cardApi: CardApi,
     private val studyApi: StudyApi,
     private val deckPresetApi: DeckPresetApi,
+    private val deckApi: DeckApi,
 ) {
     fun getCardsWithLearningState(
         userId: Long,
@@ -37,7 +43,63 @@ class DeckBFFService(
             )
         }
     }
+
+    fun getDecksWithDailyStudySession(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+    ): List<DeckListItem> {
+        val decks = deckApi.getDecks(userId).takeIf { it.isNotEmpty() } ?: return emptyList()
+
+        val todaySummaryByDeckId = studyApi.getTodaySummaries(
+            now = now,
+            timezone = timezone,
+            userId = userId,
+            deckIds = decks.map { it.id }.toSet(),
+        )
+
+        return decks.map { deck ->
+            DeckListItem(
+                deckId = deck.id,
+                name = deck.name,
+                description = deck.description,
+                cardCount = deck.cardCount,
+                progress = todaySummaryByDeckId.getValue(deck.id).toDeckProgress(),
+            )
+        }
+    }
 }
+
+private fun TodayStudySessionState.toDeckProgress(): StudySessionProgress =
+    when (this) {
+        is TodayStudySessionState.InProgress -> StudySessionProgress(
+            state = TodaySummaryState.IN_PROGRESS,
+            sessionId = session.sessionId,
+            studiedCardCount = session.newCardsStudied + session.reviewCardsStudied,
+            totalCardCount = session.estimatedTotal,
+        )
+
+        is TodayStudySessionState.Completed -> StudySessionProgress(
+            state = TodaySummaryState.COMPLETED,
+            sessionId = session.sessionId,
+            studiedCardCount = session.newCardsStudied + session.reviewCardsStudied,
+            totalCardCount = session.estimatedTotal,
+        )
+
+        is TodayStudySessionState.NotStarted -> StudySessionProgress(
+            state = TodaySummaryState.NOT_STARTED,
+            sessionId = null,
+            studiedCardCount = 0,
+            totalCardCount = pool.newCount + pool.reviewCount,
+        )
+
+        is TodayStudySessionState.RestDay -> StudySessionProgress(
+            state = TodaySummaryState.REST_DAY,
+            sessionId = null,
+            studiedCardCount = 0,
+            totalCardCount = 0,
+        )
+    }
 
 private fun toDeckCardItem(
     card: CardContentDto,

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckCardItem.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckCardItem.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.bff.internal
+
+data class DeckCardItem(
+    val cardId: Long,
+    val fields: Map<String, String>,
+    val badge: CardLearningStateBadge,
+    val reviewCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckListItem.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckListItem.kt
@@ -1,0 +1,18 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.study.TodaySummaryState
+
+data class DeckListItem(
+    val deckId: Long,
+    val name: String,
+    val description: String,
+    val cardCount: Int,
+    val progress: StudySessionProgress,
+)
+
+data class StudySessionProgress(
+    val state: TodaySummaryState,
+    val sessionId: Long?,
+    val studiedCardCount: Int,
+    val totalCardCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -1,11 +1,49 @@
 package com.whatever.caro.bff.internal.web
 
-import com.whatever.caro.study.StudyApi
+import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.bff.internal.DeckBFFService
+import com.whatever.caro.bff.internal.DeckCardItem
+import com.whatever.caro.bff.internal.web.response.DeckCardResponse
+import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RestController("/v1/decks")
+@Tag(name = "Deck Card Information", description = "Deck card information")
+@RestController
 class DeckBFFController(
-    private val studyApi: StudyApi,
+    private val deckBFFService: DeckBFFService,
 ) {
-    // TODO card 모듈 merge 후 추가구현
+
+    @Operation(
+        summary = "덱에 있는 카드 조회",
+        description = """
+        덱에 있는 모든 카드를 조회한다.
+        각 카드별로 학습 상태를 기반으로 NEW/REVIEW/HARD badge, 복습 수가 함께 제공된다.
+        """,
+    )
+    @GetMapping("/v2/decks/{deckId}/cards")
+    fun getCardsByDeck(
+        @Parameter(description = "덱 ID", required = true) @PathVariable deckId: Long,
+    ): ResponseEntity<ApiResponse<List<DeckCardResponse>>> {
+        val userId = SecurityUtil.currentUser().userId
+        val cards = deckBFFService.getCardsWithLearningState(
+            userId = userId,
+            deckId = deckId,
+        )
+        return ResponseEntity.ok(ApiResponse.ok(cards.map { it.toResponse() }))
+    }
 }
+
+private fun DeckCardItem.toResponse(): DeckCardResponse =
+    DeckCardResponse(
+        cardId = cardId,
+        fields = fields,
+        badge = badge,
+        reviewCount = reviewCount,
+    )

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -3,7 +3,11 @@ package com.whatever.caro.bff.internal.web
 import com.whatever.caro.auth.SecurityUtil
 import com.whatever.caro.bff.internal.DeckBFFService
 import com.whatever.caro.bff.internal.DeckCardItem
+import com.whatever.caro.bff.internal.DeckListItem
+import com.whatever.caro.bff.internal.StudySessionProgress
 import com.whatever.caro.bff.internal.web.response.DeckCardResponse
+import com.whatever.caro.bff.internal.web.response.DeckListResponse
+import com.whatever.caro.bff.internal.web.response.StudySessionProgressResponse
 import com.whatever.caro.common.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -11,12 +15,16 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 @Tag(name = "Deck Card Information", description = "Deck card information")
 @RestController
 class DeckBFFController(
+    private val clock: Clock,
     private val deckBFFService: DeckBFFService,
 ) {
 
@@ -38,6 +46,31 @@ class DeckBFFController(
         )
         return ResponseEntity.ok(ApiResponse.ok(cards.map { it.toResponse() }))
     }
+
+    @Operation(
+        summary = "홈 화면 덱 목록 조회",
+        description = """
+        홈 화면에 표시될 덱 목록을 조회한다.
+        각 덱마다 오늘의 일일학습 진행 정보(progress)가 포함된다.
+
+        totalCardCount는 모든 상태에서 "오늘 학습 목표 장 수"를 의미한다.
+        (NOT_STARTED는 오늘 학습 목표의 합, REST_DAY는 0)
+        """,
+    )
+    @GetMapping("/v1/decks")
+    fun getDecks(
+        @RequestHeader("Client-Timezone", required = true) timezone: ZoneId,
+    ): ResponseEntity<ApiResponse<List<DeckListResponse>>> {
+        val now = Instant.now(clock)
+        val userId = SecurityUtil.currentUser().userId
+
+        val decks = deckBFFService.getDecksWithDailyStudySession(
+            now = now,
+            timezone = timezone,
+            userId = userId,
+        )
+        return ResponseEntity.ok(ApiResponse.ok(decks.map { it.toResponse() }))
+    }
 }
 
 private fun DeckCardItem.toResponse(): DeckCardResponse =
@@ -46,4 +79,21 @@ private fun DeckCardItem.toResponse(): DeckCardResponse =
         fields = fields,
         badge = badge,
         reviewCount = reviewCount,
+    )
+
+private fun DeckListItem.toResponse(): DeckListResponse =
+    DeckListResponse(
+        deckId = deckId,
+        name = name,
+        description = description,
+        cardCount = cardCount,
+        progress = progress.toResponse(),
+    )
+
+private fun StudySessionProgress.toResponse(): StudySessionProgressResponse =
+    StudySessionProgressResponse(
+        state = state,
+        sessionId = sessionId,
+        studiedCardCount = studiedCardCount,
+        totalCardCount = totalCardCount,
     )

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckCardResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckCardResponse.kt
@@ -1,0 +1,10 @@
+package com.whatever.caro.bff.internal.web.response
+
+import com.whatever.caro.bff.internal.CardLearningStateBadge
+
+data class DeckCardResponse(
+    val cardId: Long,
+    val fields: Map<String, String>,
+    val badge: CardLearningStateBadge,
+    val reviewCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckListResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckListResponse.kt
@@ -1,0 +1,18 @@
+package com.whatever.caro.bff.internal.web.response
+
+import com.whatever.caro.study.TodaySummaryState
+
+data class DeckListResponse(
+    val deckId: Long,
+    val name: String,
+    val description: String,
+    val cardCount: Int,
+    val progress: StudySessionProgressResponse,
+)
+
+data class StudySessionProgressResponse(
+    val state: TodaySummaryState,
+    val sessionId: Long?,
+    val studiedCardCount: Int,
+    val totalCardCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/card/api/card/CardApi.kt
+++ b/src/main/kotlin/com/whatever/caro/card/api/card/CardApi.kt
@@ -5,4 +5,9 @@ interface CardApi {
         userId: Long,
         cardIds: Collection<Long>,
     ): Map<Long, CardContentDto>
+
+    fun getCardContentsByDeck(
+        userId: Long,
+        deckId: Long,
+    ): List<CardContentDto>
 }

--- a/src/main/kotlin/com/whatever/caro/card/api/deck/DeckPresetApi.kt
+++ b/src/main/kotlin/com/whatever/caro/card/api/deck/DeckPresetApi.kt
@@ -11,6 +11,11 @@ interface DeckPresetApi {
     fun getDeckPresetById(
         deckPresetIdSnapshot: Long,
     ): DeckPresetDto
+
+    fun getLatestDeckPresetsByDeckId(
+        userId: Long,
+        deckIds: Collection<Long>,
+    ): Map<Long, DeckPresetDto>
 }
 
 data class DeckPresetDto(

--- a/src/main/kotlin/com/whatever/caro/card/api/event/CardsDeletedEvent.kt
+++ b/src/main/kotlin/com/whatever/caro/card/api/event/CardsDeletedEvent.kt
@@ -4,4 +4,5 @@ data class CardsDeletedEvent(
     val deckId: Long,
     val deletedCount: Int,
     val userId: Long,
+    val deletedCardIds: Set<Long>,
 )

--- a/src/main/kotlin/com/whatever/caro/card/api/event/CardsDeletedEvent.kt
+++ b/src/main/kotlin/com/whatever/caro/card/api/event/CardsDeletedEvent.kt
@@ -1,8 +1,11 @@
 package com.whatever.caro.card.api.event
 
+import java.time.Instant
+
 data class CardsDeletedEvent(
     val deckId: Long,
     val deletedCount: Int,
     val userId: Long,
     val deletedCardIds: Set<Long>,
+    val deletedAt: Instant,
 )

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -44,6 +44,7 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
+    @Deprecated(message = "v2 메서드로 변경 필요")
     @GetMapping("/v1/decks/{deckId}/cards")
     fun getCardsByDeck(
         @Parameter(description = "덱 ID", required = true)

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -165,10 +165,12 @@ class CardService(
         deckId: Long,
     ): List<CardContentDto> {
         val cardResponseDtos = getCardsByDeck(userId, deckId)
-        return cardResponseDtos.map { CardContentDto(
-            cardId = it.cardId,
-            fields = it.fields,
-        ) }
+        return cardResponseDtos.map {
+            CardContentDto(
+                cardId = it.cardId,
+                fields = it.fields,
+            )
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -159,6 +159,18 @@ class CardService(
             }
     }
 
+    @Transactional(readOnly = true)
+    override fun getCardContentsByDeck(
+        userId: Long,
+        deckId: Long,
+    ): List<CardContentDto> {
+        val cardResponseDtos = getCardsByDeck(userId, deckId)
+        return cardResponseDtos.map { CardContentDto(
+            cardId = it.cardId,
+            fields = it.fields,
+        ) }
+    }
+
     @Transactional
     fun updateCard(
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -208,7 +208,8 @@ class CardService(
                 deckId = card.deck.id,
                 deletedCount = 1,
                 userId = userId,
-                deletedCardIds = setOf(card.id)),
+                deletedCardIds = setOf(card.id),
+            ),
         )
 
         return DeleteCardResponseDto(cardId = card.id)

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -27,6 +27,7 @@ import com.whatever.caro.card.internal.notetype.exception.NoteTypeNotFoundExcept
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.Instant
 
 @Service
@@ -37,6 +38,7 @@ class CardService(
     private val noteTypeRepository: NoteTypeRepository,
     private val cardTemplateRepository: CardTemplateRepository,
     private val eventPublisher: ApplicationEventPublisher,
+    private val clock: Clock,
 ) : CardApi {
     override fun getCardsByIds(
         userId: Long,
@@ -195,7 +197,7 @@ class CardService(
             throw CardForbiddenException("cardId=${dto.cardId} 에 대한 접근 권한이 없습니다")
         }
 
-        val now = Instant.now()
+        val now = Instant.now(clock)
         card.softDelete(deletedAt = now)
         card.deck.cardCount = maxOf(0, card.deck.cardCount - 1)
 
@@ -209,6 +211,7 @@ class CardService(
                 deletedCount = 1,
                 userId = userId,
                 deletedCardIds = setOf(card.id),
+                deletedAt = now,
             ),
         )
 

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -204,7 +204,11 @@ class CardService(
         }
 
         eventPublisher.publishEvent(
-            CardsDeletedEvent(deckId = card.deck.id, deletedCount = 1, userId = userId),
+            CardsDeletedEvent(
+                deckId = card.deck.id,
+                deletedCount = 1,
+                userId = userId,
+                deletedCardIds = setOf(card.id)),
         )
 
         return DeleteCardResponseDto(cardId = card.id)

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
@@ -5,6 +5,20 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface DeckRepository : JpaRepository<Deck, Long> {
+    @Query(
+        """
+        select d from Deck d
+            join fetch d.deckPreset
+        where d.id in :deckIds
+            and d.userId = :userId
+            and d.deletedAt is null
+        """,
+    )
+    fun findAllByIdInWithPreset(
+        userId: Long,
+        deckIds: Collection<Long>,
+    ): List<Deck>
+
     fun findByUserIdAndDeletedAtIsNull(
         userId: Long,
     ): List<Deck>

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetService.kt
@@ -19,6 +19,18 @@ class DeckPresetService(
 ) : DeckPresetApi {
 
     @Transactional(readOnly = true)
+    override fun getLatestDeckPresetsByDeckId(
+        userId: Long,
+        deckIds: Collection<Long>,
+    ): Map<Long, DeckPresetDto> =
+        deckRepository.findAllByIdInWithPreset(
+            userId = userId,
+            deckIds = deckIds,
+        ).mapNotNull { deck ->
+            deck.deckPreset?.let { deck.id to it.toDto() }
+        }.toMap()
+
+    @Transactional(readOnly = true)
     override fun getLatestDeckPresetByUser(
         deckId: Long,
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/common/config/ClockConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/ClockConfig.kt
@@ -3,9 +3,13 @@ package com.whatever.caro.common.config
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Clock
+import java.time.Duration
 
 @Configuration
 class ClockConfig {
+    /**
+     * OS마다 Clock의 정밀도 차이가 존재하며, 일관된 시간을 보장하기 위해 마이크로초 단위로 truncate한다
+     */
     @Bean
-    fun clock(): Clock = Clock.systemUTC()
+    fun clock(): Clock = Clock.tick(Clock.systemUTC(), Duration.ofNanos(1000))
 }

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -27,4 +27,11 @@ interface StudyApi {
         sessionId: Long,
         now: Instant,
     ): List<CardLearningStateDto>
+
+    fun getTodaySummaries(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+        deckIds: Set<Long>,
+    ): Map<Long, TodayStudySessionState>
 }

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -6,18 +6,6 @@ import java.time.ZoneId
 // TODO StudySessionApi로 분리
 interface StudyApi {
     /**
-     * 오늘 학습 세션에 대한 정보를 반환한다.
-     *
-     * 시각은 caller(요청 진입 시점)가 결정한 단일 `now`를 전달받아 도메인 호출 간 일관성을 보장한다.
-     */
-    fun getTodaySummary(
-        now: Instant,
-        timezone: ZoneId,
-        userId: Long,
-        deckId: Long,
-    ): TodayStudySessionState
-
-    /**
      * 카드별 LearningStates를 cardId 기준 맵으로 반환한다.
      */
     fun getLearningStates(

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -18,8 +18,7 @@ interface StudyApi {
     ): TodayStudySessionState
 
     /**
-     * 카드별 학습 상태를 cardId 기준 맵으로 반환한다.
-     * 평가 이력이 없는 카드는 맵에 포함되지 않으므로, 호출 측에서 부재를 처리한다.
+     * 카드별 LearningStates를 cardId 기준 맵으로 반환한다.
      */
     fun getLearningStates(
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/study/StudyTargetPoolCalculator.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyTargetPoolCalculator.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.study
 
+import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -42,6 +43,36 @@ class StudyTargetPoolCalculator(
             newCount = newPool,
             reviewCount = reviewPool,
         )
+    }
+
+    @Transactional(readOnly = true)
+    fun getTodayPools(
+        now: Instant,
+        timezone: ZoneId,
+        presetByDeckId: Map<Long, DeckPresetDto>,
+        dayCutoffHour: Int,
+    ): Map<Long, StudyTargetPoolCount> {
+        if (presetByDeckId.isEmpty()) {
+            return emptyMap()
+        }
+
+        val nextSessionStart = getNextSessionStart(now, timezone, dayCutoffHour)
+
+        val deckIds = presetByDeckId.keys
+        val newCardCountByDeckId = cardLearningStateRepository.countNewCardsByDeckIds(
+            deckIds = deckIds,
+        ).associate { it.deckId to it.count.toInt() }
+        val reviewCardCountByDeckId = cardLearningStateRepository.countReviewCardsByDeckIds(
+            deckIds = deckIds,
+            nextSessionStart = nextSessionStart,
+        ).associate { it.deckId to it.count.toInt() }
+
+        return presetByDeckId.mapValues { (deckId, preset) ->
+            StudyTargetPoolCount(
+                newCount = min(preset.newPerDay, newCardCountByDeckId[deckId] ?: 0),
+                reviewCount = min(preset.reviewPerDay, reviewCardCountByDeckId[deckId] ?: 0),
+            )
+        }
     }
 
     /**

--- a/src/main/kotlin/com/whatever/caro/study/internal/DeckCardCount.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/DeckCardCount.kt
@@ -1,0 +1,6 @@
+package com.whatever.caro.study.internal
+
+data class DeckCardCount(
+    val deckId: Long,
+    val count: Long,
+)

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
@@ -45,7 +45,7 @@ class EvaluationService(
 
         // 평가 아이템 검증
         val dedupedItems = items.asReversed().distinctBy { it.cardId }.asReversed()
-        val clsByCardId = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+        val clsByCardId = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
             userId = userId,
             cardIds = dedupedItems.map { it.cardId },
         ).associateBy { it.cardId }

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
@@ -90,9 +90,7 @@ class EvaluationService(
             session.updateStudiedCard(reviewLog.reviewType)
             reviewLog
         }
-        if (session.newCardsStudied + session.reviewCardsStudied >= session.estimatedTotal) {
-            session.complete(now)
-        }
+        session.completeIfGoalAchieved(now)
 
         reviewLogRepository.saveAll(newReviewLogs)
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -227,6 +227,62 @@ class StudyService(
         val learningStates = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(userId, cardIds)
         return learningStates.associate { it.cardId to it.toDto() }
     }
+
+    @Transactional(readOnly = true)
+    override fun getTodaySummaries(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+        deckIds: Set<Long>,
+    ): Map<Long, TodayStudySessionState> {
+        if (deckIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        val todaySessionByDeckId = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+            userId,
+            deckIds,
+        ).filter { session ->
+            when (session.status) {
+                StudySessionStatus.ACTIVE, StudySessionStatus.COMPLETED -> session.isTodaySession(now)
+                StudySessionStatus.STOPPED -> false
+            }
+        }.associateBy { it.deckId }
+
+        val noSessionDeckIds = deckIds - todaySessionByDeckId.keys
+        val presetByDeckId = if (noSessionDeckIds.isNotEmpty()) {
+            deckPresetApi.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = noSessionDeckIds,
+            )
+        } else {
+            emptyMap()
+        }
+        val todayPoolByDeckId = studyTargetPoolCalculator.getTodayPools(
+            now = now,
+            timezone = timezone,
+            presetByDeckId = presetByDeckId,
+            dayCutoffHour = 0,
+        )
+
+        return deckIds.associateWith { deckId ->
+            todaySessionByDeckId[deckId]?.let { session ->
+                if (session.status == StudySessionStatus.ACTIVE) {
+                    TodayStudySessionState.InProgress(session.toDto())
+                } else {
+                    TodayStudySessionState.Completed(session.toDto())
+                }
+            } ?: run {
+                val preset = checkNotNull(presetByDeckId[deckId]) { "deck에 연결된 preset이 없습니다. deckId=$deckId" }
+                val pool = todayPoolByDeckId.getValue(deckId)
+                if (pool.newCount == 0 && pool.reviewCount == 0) {
+                    TodayStudySessionState.RestDay
+                } else {
+                    TodayStudySessionState.NotStarted(pool, preset.id)
+                }
+            }
+        }
+    }
 }
 
 private fun CardLearningState.toDto(): CardLearningStateDto =

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -119,7 +119,7 @@ class StudyService(
     }
 
     @Transactional(readOnly = true)
-    override fun getTodaySummary(
+    fun getTodaySummary(
         now: Instant,
         timezone: ZoneId,
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -32,7 +32,8 @@ class StudyService(
 ) : StudyApi {
 
     @Transactional
-    override fun startOrResumeDailyStudySession( // TODO 동시성 고려
+    override fun startOrResumeDailyStudySession(
+        // TODO 동시성 고려
         now: Instant,
         userId: Long,
         deckId: Long,
@@ -130,6 +131,33 @@ class StudyService(
             userId = userId,
             deckId = deckId,
         )
+
+    @Transactional
+    fun adjustGoalsOnCardDeletion(
+        now: Instant,
+        userId: Long,
+        deckId: Long,
+    ) {
+        val session = findTodaySession(now = now, userId = userId, deckId = deckId)
+            ?.takeIf { it.status == StudySessionStatus.ACTIVE }
+            ?: return
+
+        val availableNewCount = cardLearningStateRepository.countRemainingNewCards(
+            userId = userId,
+            deckId = deckId,
+            sessionStart = session.sessionStart,
+        )
+        val availableReviewCount = cardLearningStateRepository.countTodayReviewCards(
+            userId = userId,
+            deckId = deckId,
+            nextSessionStart = session.nextSessionStart,
+        )
+        session.recalculateGoals(
+            availableNewGoal = availableNewCount,
+            availableReviewGoal = availableReviewCount,
+        )
+        session.completeIfGoalAchieved(now)
+    }
 
     private fun resolveTodayStudy(
         now: Instant,

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -196,7 +196,7 @@ class StudyService(
         userId: Long,
         cardIds: Collection<Long>,
     ): Map<Long, CardLearningStateDto> {
-        val learningStates = cardLearningStateRepository.findAllByUserIdAndCardIdIn(userId, cardIds)
+        val learningStates = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(userId, cardIds)
         return learningStates.associate { it.cardId to it.toDto() }
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningState.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningState.kt
@@ -1,6 +1,7 @@
 package com.whatever.caro.study.internal.cardlearningstate
 
 import com.whatever.caro.common.entity.BaseTimeEntity
+import com.whatever.caro.common.entity.SoftDeletableEntity
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.internal.SchedulingState
 import com.whatever.caro.study.internal.SchedulingState.New
@@ -59,7 +60,7 @@ class CardLearningState(
 
     @Column(name = "total_reviews", nullable = false)
     var totalReviews: Int = 0,
-) : BaseTimeEntity() {
+) : SoftDeletableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -78,4 +78,24 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
         pageable: Pageable,
         sessionStart: Instant,
     ): List<CardLearningState>
+
+    /**
+     * 오늘 학습하지 않은, NEW 상태인 LearningState를 반환
+     */
+    @Query(
+        """
+        select cls from CardLearningState cls
+        where cls.userId = :userId
+            and cls.deckId = :deckId
+            and cls.status = CardLearningStatus.NEW
+            and (cls.lastReviewedAt is null or cls.lastReviewedAt < :sessionStart)
+            and cls.deletedAt is null
+        order by cls.id asc
+        """,
+    )
+    fun countRemainingNewCards(
+        userId: Long,
+        deckId: Long,
+        sessionStart: Instant,
+    ): Int
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import java.time.Instant
 
 interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
-    fun findAllByUserIdAndCardIdIn(
+    fun findAllByUserIdAndCardIdInAndDeletedAtIsNull(
         userId: Long,
         cardIds: Collection<Long>,
     ): List<CardLearningState>
@@ -18,6 +18,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
             and cls.deckId = :deckId
             and cls.nextReviewAt < :nextSessionStart
             and cls.status = CardLearningStatus.REVIEW
+            and cls.deletedAt is null
     """,
     )
     fun countTodayReviewCards(
@@ -32,6 +33,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
         where cls.userId = :userId
             and cls.deckId = :deckId
             and cls.status = CardLearningStatus.NEW
+            and cls.deletedAt is null
     """,
     )
     fun countNewCards(
@@ -47,6 +49,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
             and cls.status = CardLearningStatus.REVIEW
             and cls.nextReviewAt < :nextSessionStart
             and (cls.lastReviewedAt is null or cls.lastReviewedAt < :sessionStart)
+            and cls.deletedAt is null
         order by cls.nextReviewAt asc, cls.id asc
     """,
     )
@@ -65,6 +68,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
             and cls.deckId = :deckId
             and cls.status = CardLearningStatus.NEW
             and (cls.lastReviewedAt is null or cls.lastReviewedAt < :sessionStart)
+            and cls.deletedAt is null
         order by cls.id asc
     """,
     )

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.study.internal.cardlearningstate
 
+import com.whatever.caro.study.internal.DeckCardCount
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -98,4 +99,32 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
         deckId: Long,
         sessionStart: Instant,
     ): Int
+
+    @Query(
+        """
+        select new com.whatever.caro.study.internal.DeckCardCount(cls.deckId, count(cls)) from CardLearningState cls
+        where cls.deckId in :deckIds
+            and cls.status = CardLearningStatus.NEW
+            and cls.deletedAt is null
+        group by cls.deckId
+        """,
+    )
+    fun countNewCardsByDeckIds(
+        deckIds: Collection<Long>,
+    ): List<DeckCardCount>
+
+    @Query(
+        """
+        select new com.whatever.caro.study.internal.DeckCardCount(cls.deckId, count(cls)) from CardLearningState cls
+        where cls.deckId in :deckIds
+            and cls.status = CardLearningStatus.REVIEW
+            and cls.deletedAt is null
+            and cls.nextReviewAt < :nextSessionStart
+        group by cls.deckId
+        """,
+    )
+    fun countReviewCardsByDeckIds(
+        deckIds: Collection<Long>,
+        nextSessionStart: Instant,
+    ): List<DeckCardCount>
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -13,7 +13,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
 
     @Query(
         """
-        select count(*) from CardLearningState cls
+        select count(cls) from CardLearningState cls
         where cls.userId = :userId
             and cls.deckId = :deckId
             and cls.nextReviewAt < :nextSessionStart
@@ -29,7 +29,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
 
     @Query(
         """
-        select count(*) from CardLearningState cls
+        select count(cls) from CardLearningState cls
         where cls.userId = :userId
             and cls.deckId = :deckId
             and cls.status = CardLearningStatus.NEW
@@ -84,7 +84,7 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
      */
     @Query(
         """
-        select cls from CardLearningState cls
+        select count(cls) from CardLearningState cls
         where cls.userId = :userId
             and cls.deckId = :deckId
             and cls.status = CardLearningStatus.NEW

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
@@ -1,6 +1,8 @@
-package com.whatever.caro.study.internal.cardlearningstate
+package com.whatever.caro.study.internal.event
 
 import com.whatever.caro.card.api.event.CardsCreatedEvent
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
@@ -1,13 +1,17 @@
 package com.whatever.caro.study.internal.event
 
 import com.whatever.caro.card.api.event.CardsCreatedEvent
+import com.whatever.caro.card.api.event.CardsDeletedEvent
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
 
 @Component
 internal class CardLearningStateEventListener(
+    private val clock: Clock,
     private val cardLearningStateRepository: CardLearningStateRepository,
 ) {
     @ApplicationModuleListener
@@ -18,5 +22,17 @@ internal class CardLearningStateEventListener(
             CardLearningState(cardId = cardId, deckId = event.deckId, userId = event.userId)
         }
         cardLearningStateRepository.saveAll(states)
+    }
+
+    @ApplicationModuleListener
+    fun onCardDeleted(
+        event: CardsDeletedEvent,
+    ) {
+        val now = Instant.now(clock)
+        val orphans = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
+            userId = event.userId,
+            cardIds = event.deletedCardIds,
+        )
+        orphans.forEach { it.softDelete(now) }
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
@@ -2,6 +2,7 @@ package com.whatever.caro.study.internal.event
 
 import com.whatever.caro.card.api.event.CardsCreatedEvent
 import com.whatever.caro.card.api.event.CardsDeletedEvent
+import com.whatever.caro.study.internal.StudyService
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import org.springframework.modulith.events.ApplicationModuleListener
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component
 @Component
 internal class CardLearningStateEventListener(
     private val cardLearningStateRepository: CardLearningStateRepository,
+    private val studyService: StudyService,
 ) {
     @ApplicationModuleListener
     fun onCardsCreated(
@@ -28,7 +30,14 @@ internal class CardLearningStateEventListener(
         val orphans = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
             userId = event.userId,
             cardIds = event.deletedCardIds,
-        )
+        ).takeIf { it.isNotEmpty() } ?: return
         orphans.forEach { it.softDelete(event.deletedAt) }
+        cardLearningStateRepository.saveAll(orphans)  // flush orphans
+
+        studyService.adjustGoalsOnCardDeletion(
+            now = event.deletedAt,
+            userId = event.userId,
+            deckId = event.deckId,
+        )
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
@@ -32,7 +32,7 @@ internal class CardLearningStateEventListener(
             cardIds = event.deletedCardIds,
         ).takeIf { it.isNotEmpty() } ?: return
         orphans.forEach { it.softDelete(event.deletedAt) }
-        cardLearningStateRepository.saveAll(orphans)  // flush orphans
+        cardLearningStateRepository.saveAll(orphans) // flush orphans
 
         studyService.adjustGoalsOnCardDeletion(
             now = event.deletedAt,

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListener.kt
@@ -6,12 +6,9 @@ import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
-import java.time.Clock
-import java.time.Instant
 
 @Component
 internal class CardLearningStateEventListener(
-    private val clock: Clock,
     private val cardLearningStateRepository: CardLearningStateRepository,
 ) {
     @ApplicationModuleListener
@@ -28,11 +25,10 @@ internal class CardLearningStateEventListener(
     fun onCardDeleted(
         event: CardsDeletedEvent,
     ) {
-        val now = Instant.now(clock)
         val orphans = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
             userId = event.userId,
             cardIds = event.deletedCardIds,
         )
-        orphans.forEach { it.softDelete(now) }
+        orphans.forEach { it.softDelete(event.deletedAt) }
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -1,7 +1,6 @@
 package com.whatever.caro.study.internal.studysession
 
 import com.whatever.caro.common.entity.BaseTimeEntity
-import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.ReviewType
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
@@ -102,5 +101,21 @@ class StudySession(
     ) {
         status = StudySessionStatus.COMPLETED
         endedAt = now
+    }
+
+    fun recalculateGoals(
+        availableNewGoal: Int,
+        availableReviewGoal: Int,
+    ) {
+        newCardsGoal = minOf(newCardsGoal, (newCardsStudied + availableNewGoal))
+        reviewCardsGoal = minOf(reviewCardsGoal, (reviewCardsStudied + availableReviewGoal))
+    }
+
+    fun completeIfGoalAchieved(
+        now: Instant,
+    ) {
+        if ((newCardsStudied >= newCardsGoal) && (reviewCardsStudied >= reviewCardsGoal)) {
+            complete(now)
+        }
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -4,6 +4,7 @@ import com.whatever.caro.common.entity.BaseTimeEntity
 import com.whatever.caro.study.ReviewType
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -16,6 +17,8 @@ import org.springframework.data.annotation.Transient
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+
+private val logger = KotlinLogging.logger {}
 
 @Entity
 @Table(name = "study_sessions")
@@ -116,6 +119,9 @@ class StudySession(
     ) {
         if ((newCardsStudied >= newCardsGoal) && (reviewCardsStudied >= reviewCardsGoal)) {
             complete(now)
+        }
+        if (newCardsGoal == 0 && reviewCardsGoal == 0) {
+            logger.debug { "All cards deleted. Session status updated: $status. sessionId: $id" }
         }
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -96,7 +96,7 @@ class StudySession(
         }
     }
 
-    fun complete(
+    private fun complete(
         now: Instant,
     ) {
         status = StudySessionStatus.COMPLETED

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -110,8 +110,8 @@ class StudySession(
         availableNewGoal: Int,
         availableReviewGoal: Int,
     ) {
-        newCardsGoal = minOf(newCardsGoal, (newCardsStudied + availableNewGoal))
-        reviewCardsGoal = minOf(reviewCardsGoal, (reviewCardsStudied + availableReviewGoal))
+        newCardsGoal = (newCardsStudied + availableNewGoal).coerceAtMost(newCardsGoal)
+        reviewCardsGoal = (reviewCardsStudied + availableReviewGoal).coerceAtMost(reviewCardsGoal)
     }
 
     fun completeIfGoalAchieved(

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepository.kt
@@ -37,4 +37,23 @@ interface StudySessionRepository : JpaRepository<StudySession, Long> {
         id: Long,
         userId: Long,
     ): StudySession?
+
+    @Query(
+        """
+        select ss from StudySession ss
+        where ss.userId = :userId
+            and ss.deckId in :deckIds
+            and not exists (
+                select 1 from StudySession ss2
+                where ss2.userId = :userId
+                    and ss2.deckId = ss.deckId
+                    and (ss2.startedAt > ss.startedAt
+                            or (ss2.startedAt = ss.startedAt and ss2.id > ss.id))
+            )
+        """,
+    )
+    fun findLatestByUserIdAndDeckIdIn(
+        userId: Long,
+        deckIds: Set<Long>,
+    ): List<StudySession>
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -30,6 +30,7 @@ logging:
     com.whatever.caro: debug
     org.flywaydb: debug
     org.springframework.modulith: debug
+    org.hibernate.sql: debug
 
 server:
   port: 8081

--- a/src/main/resources/db/migration/study/V6__card_learning_state_add_deletedat.sql
+++ b/src/main/resources/db/migration/study/V6__card_learning_state_add_deletedat.sql
@@ -1,0 +1,2 @@
+ALTER TABLE card_learning_states
+    ADD COLUMN deleted_at DATETIME(6) NULL;

--- a/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
@@ -1,0 +1,200 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.card.api.card.CardApi
+import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckPresetApi
+import com.whatever.caro.card.api.deck.DeckPresetDto
+import com.whatever.caro.study.CardLearningStateDto
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudyApi
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.engine.test.logging.error
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.math.BigDecimal
+
+class DeckBFFServiceUnitTest :
+    DescribeSpec({
+
+        val cardApi = mockk<CardApi>()
+        val studyApi = mockk<StudyApi>()
+        val deckPresetApi = mockk<DeckPresetApi>()
+        val service = DeckBFFService(cardApi = cardApi, studyApi = studyApi, deckPresetApi = deckPresetApi)
+
+        val userId = 1L
+        val deckId = 7L
+
+        fun createCardContent(
+            cardId: Long,
+        ): CardContentDto =
+            CardContentDto(
+                cardId = cardId,
+                fields = mapOf("front" to "Q$cardId", "back" to "A$cardId"),
+            )
+
+        fun createCls(
+            cardId: Long,
+            status: CardLearningStatus = CardLearningStatus.NEW,
+            totalReviews: Int = 0,
+            consecutiveAgainCount: Int = 0,
+        ): CardLearningStateDto =
+            CardLearningStateDto(
+                cardId = cardId,
+                status = status,
+                totalReviews = totalReviews,
+                consecutiveAgainCount = consecutiveAgainCount,
+            )
+
+        fun createPreset(
+            hardBadgeThreshold: Int = 3,
+        ): DeckPresetDto =
+            DeckPresetDto(
+                id = 1L,
+                userId = userId,
+                name = "기본 프리셋",
+                newPerDay = 10,
+                newFairInterval = 1,
+                newEasyInterval = 4,
+                newInitialEaseFactor = BigDecimal("2.5"),
+                reviewPerDay = 100,
+                reviewMaxInterval = 365,
+                lapseIntervalMultiplier = BigDecimal("0.5"),
+                lapseMinInterval = 1,
+                leechThreshold = 8,
+                hardBadgeThreshold = hardBadgeThreshold,
+            )
+
+        fun stubDeckInformation(
+            cards: List<CardContentDto>,
+            states: List<CardLearningStateDto>,
+            hardBadgeThreshold: Int = 3,
+        ) {
+            every {
+                cardApi.getCardContentsByDeck(userId = userId, deckId = deckId)
+            } returns cards
+
+            every {
+                studyApi.getLearningStates(userId = userId, cardIds = cards.map { it.cardId })
+            } returns states.associateBy { it.cardId }
+
+            every {
+                deckPresetApi.getLatestDeckPresetByUser(deckId = deckId, userId = userId)
+            } returns createPreset(hardBadgeThreshold = hardBadgeThreshold)
+        }
+
+        afterTest {
+            clearMocks(cardApi, studyApi, deckPresetApi)
+        }
+
+        describe("getCardsWithLearningState") {
+
+            it("덱 카드들을 learningState/preset과 조합해 순서를 유지하며 DeckCardItem 리스트로 매핑한다") {
+                val cards = (1L..3L).map { i -> createCardContent(i) }
+                val states = listOf(
+                    createCls(cardId = 1L, status = CardLearningStatus.NEW, totalReviews = 0, consecutiveAgainCount = 0),
+                    createCls(cardId = 2L, status = CardLearningStatus.REVIEW, totalReviews = 3, consecutiveAgainCount = 1),
+                    createCls(cardId = 3L, status = CardLearningStatus.REVIEW, totalReviews = 10, consecutiveAgainCount = 2),
+                )
+                stubDeckInformation(cards = cards, states = states, hardBadgeThreshold = 8)
+
+                val result = service.getCardsWithLearningState(userId, deckId)
+
+                result.map { it.cardId } shouldContainExactly cards.map { it.cardId }
+                repeat(3) { i ->
+                    when (states[i].status) {
+                        CardLearningStatus.NEW -> result[i].badge shouldBe CardLearningStateBadge.NEW
+                        CardLearningStatus.REVIEW -> result[i].badge shouldBe CardLearningStateBadge.REVIEW
+                        CardLearningStatus.SUSPENDED -> error("SUSPENDED status is not supported")
+                    }
+                    result[i].reviewCount shouldBe states[i].totalReviews
+                }
+            }
+
+            context("early return 케이스") {
+                it("덱에 카드가 없으면 빈 리스트를 반환하고 study/preset API를 호출하지 않는다") {
+                    every { cardApi.getCardContentsByDeck(userId = userId, deckId = deckId) } returns emptyList()
+
+                    val result = service.getCardsWithLearningState(userId, deckId)
+
+                    result.shouldBeEmpty()
+                    verify(exactly = 0) { studyApi.getLearningStates(any(), any()) }
+                    verify(exactly = 0) { deckPresetApi.getLatestDeckPresetByUser(any(), any()) }
+                }
+            }
+
+            it("learningState가 없는 카드는 badge=NEW, reviewCount=0으로 반환한다") {
+                val cards = listOf(createCardContent(1L), createCardContent(2L))
+
+                // 2L 카드 누락
+                val states = listOf(createCls(1L, status = CardLearningStatus.REVIEW, totalReviews = 4))
+                stubDeckInformation(
+                    cards = cards,
+                    states = states,
+                )
+
+                val result = service.getCardsWithLearningState(userId, deckId)
+
+                result[0].badge shouldBe CardLearningStateBadge.REVIEW
+                result[0].reviewCount shouldBe states.first().totalReviews
+                result[1].badge shouldBe CardLearningStateBadge.NEW
+                result[1].reviewCount shouldBe 0
+            }
+
+            context("badge 매핑 확인") {
+                data class BadgeCase(
+                    val againCount: Int,
+                    val threshold: Int,
+                    val status: CardLearningStatus,
+                    val expected: CardLearningStateBadge,
+                    val reason: String,
+                )
+
+                withData(
+                    nameFn = {
+                        "againCount=${it.againCount}, threshold=${it.threshold}, " +
+                            "status=${it.status} -> ${it.expected} (${it.reason})"
+                    },
+                    BadgeCase(2, 3, CardLearningStatus.NEW, CardLearningStateBadge.NEW, "미만이면 baseBadge 유지"),
+                    BadgeCase(2, 3, CardLearningStatus.REVIEW, CardLearningStateBadge.REVIEW, "미만이면 baseBadge 유지"),
+                    BadgeCase(3, 3, CardLearningStatus.REVIEW, CardLearningStateBadge.HARD, "threshold==againCount"),
+                    BadgeCase(4, 3, CardLearningStatus.REVIEW, CardLearningStateBadge.HARD, "threshold 초과"),
+                    BadgeCase(3, 3, CardLearningStatus.NEW, CardLearningStateBadge.HARD, "NEW여도 HARD가 우선 반영"),
+                    BadgeCase(0, 0, CardLearningStatus.NEW, CardLearningStateBadge.HARD, "threshold=0이면 0회도 HARD"),
+                ) { (againCount, threshold, status, expected, _) ->
+                    val cardId = 1L
+                    val cards = listOf(createCardContent(cardId))
+                    val states = listOf(createCls(cardId, status = status, consecutiveAgainCount = againCount))
+                    stubDeckInformation(
+                        cards = cards,
+                        states = states,
+                        hardBadgeThreshold = threshold,
+                    )
+
+                    val result = service.getCardsWithLearningState(userId, deckId)
+
+                    result.first().badge shouldBe expected
+                }
+
+                it("SUSPENDED status는 지원하지 않으므로 IllegalStateException을 던진다") {
+                    val cardId = 1L
+                    val cards = listOf(createCardContent(cardId))
+                    val states = listOf(createCls(1L, status = CardLearningStatus.SUSPENDED))
+                    stubDeckInformation(
+                        cards = cards,
+                        states = states,
+                    )
+
+                    shouldThrow<IllegalStateException> {
+                        service.getCardsWithLearningState(userId, deckId)
+                    }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
@@ -2,6 +2,7 @@ package com.whatever.caro.bff.internal
 
 import com.whatever.caro.card.api.card.CardApi
 import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckApi
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.CardLearningStateDto
@@ -10,7 +11,6 @@ import com.whatever.caro.study.StudyApi
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
-import io.kotest.engine.test.logging.error
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -26,10 +26,11 @@ class DeckBFFServiceUnitTest :
         val cardApi = mockk<CardApi>()
         val studyApi = mockk<StudyApi>()
         val deckPresetApi = mockk<DeckPresetApi>()
-        val service = DeckBFFService(cardApi = cardApi, studyApi = studyApi, deckPresetApi = deckPresetApi)
+        val deckApi = mockk<DeckApi>()
+        val service = DeckBFFService(cardApi = cardApi, studyApi = studyApi, deckPresetApi = deckPresetApi, deckApi = deckApi)
 
         val userId = 1L
-        val deckId = 7L
+        val deckId = 1L
 
         fun createCardContent(
             cardId: Long,

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
@@ -33,6 +33,9 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class CardServiceUnitTest :
     DescribeSpec({
@@ -43,6 +46,8 @@ class CardServiceUnitTest :
         val noteTypeRepository = mockk<NoteTypeRepository>()
         val cardTemplateRepository = mockk<CardTemplateRepository>()
         val eventPublisher = mockk<org.springframework.context.ApplicationEventPublisher>(relaxed = true)
+        val fixedNow = Instant.parse("2026-06-08T00:00:00.00Z")
+        val clock = Clock.fixed(fixedNow, ZoneId.of("UTC"))
         val cardService = CardService(
             cardRepository = cardRepository,
             noteRepository = noteRepository,
@@ -50,6 +55,7 @@ class CardServiceUnitTest :
             noteTypeRepository = noteTypeRepository,
             cardTemplateRepository = cardTemplateRepository,
             eventPublisher = eventPublisher,
+            clock = clock,
         )
 
         beforeEach {
@@ -484,7 +490,10 @@ class CardServiceUnitTest :
                 every { cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(300L) } returns card
                 every { cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(200L, 300L) } returns 1L
 
-                val result = cardService.deleteCard(userId, DeleteCardDto(cardId = 300L))
+                val result = cardService.deleteCard(
+                    userId = userId,
+                    dto = DeleteCardDto(cardId = 300L),
+                )
 
                 result.cardId shouldBe 300L
                 card.isDeleted.shouldBeTrue()
@@ -492,7 +501,13 @@ class CardServiceUnitTest :
                 deck.cardCount shouldBe 2
                 verify {
                     eventPublisher.publishEvent(
-                        CardsDeletedEvent(deckId = 10L, deletedCount = 1, userId = userId, deletedCardIds = setOf(card.id)),
+                        CardsDeletedEvent(
+                            deckId = 10L,
+                            deletedCount = 1,
+                            userId = userId,
+                            deletedCardIds = setOf(card.id),
+                            deletedAt = fixedNow,
+                        ),
                     )
                 }
             }

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
@@ -492,7 +492,7 @@ class CardServiceUnitTest :
                 deck.cardCount shouldBe 2
                 verify {
                     eventPublisher.publishEvent(
-                        CardsDeletedEvent(deckId = 10L, deletedCount = 1, userId = userId),
+                        CardsDeletedEvent(deckId = 10L, deletedCount = 1, userId = userId, deletedCardIds = setOf(card.id)),
                     )
                 }
             }

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetServiceTest.kt
@@ -10,6 +10,7 @@ import com.whatever.caro.card.internal.deck.exception.DeckNotFoundException
 import com.whatever.caro.card.internal.deck.exception.DeckPresetNotFoundException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
@@ -86,6 +87,96 @@ class DeckPresetServiceTest(
             shouldThrow<DeckPresetNotFoundException> {
                 deckPresetService.getLatestDeckPresetByUser(deck.id, userId)
             }
+        }
+    }
+
+    describe("getLatestDeckPresetsByDeckId") {
+        it("덱별로 연결된 프리셋이 deckId 기준 맵으로 반환된다") {
+            val userId = 1L
+            val preset1 = savePreset(userId = userId, name = "프리셋1")
+            val preset2 = savePreset(userId = userId, name = "프리셋2")
+            val deck1 = saveDeck(userId = userId, preset = preset1)
+            val deck2 = saveDeck(userId = userId, preset = preset2)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deck1.id, deck2.id),
+            )
+
+            result.keys shouldBe setOf(deck1.id, deck2.id)
+            result[deck1.id]?.id shouldBe preset1.id
+            result[deck2.id]?.id shouldBe preset2.id
+        }
+
+        it("여러 덱이 같은 프리셋을 공유하면 모든 deckId 키가 같은 프리셋을 가리킨다") {
+            val userId = 1L
+            val sharedPreset = savePreset(userId = userId, name = "공유 프리셋")
+            val deck1 = saveDeck(userId = userId, preset = sharedPreset)
+            val deck2 = saveDeck(userId = userId, preset = sharedPreset)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deck1.id, deck2.id),
+            )
+
+            result[deck1.id]?.id shouldBe sharedPreset.id
+            result[deck2.id]?.id shouldBe sharedPreset.id
+        }
+
+        it("프리셋이 연결되지 않은 덱은 결과 키에서 제외된다") {
+            val userId = 1L
+            val preset = savePreset(userId = userId)
+            val deckWithPreset = saveDeck(userId = userId, preset = preset)
+            val deckWithoutPreset = saveDeck(userId = userId, preset = null)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deckWithPreset.id, deckWithoutPreset.id),
+            )
+
+            result.keys shouldBe setOf(deckWithPreset.id)
+        }
+
+        it("다른 유저의 덱은 결과 키에서 제외된다") {
+            val myPreset = savePreset(userId = 1L)
+            val otherPreset = savePreset(userId = 2L)
+            val myDeck = saveDeck(userId = 1L, preset = myPreset)
+            val otherDeck = saveDeck(userId = 2L, preset = otherPreset)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = 1L,
+                deckIds = setOf(myDeck.id, otherDeck.id),
+            )
+
+            result.keys shouldBe setOf(myDeck.id)
+        }
+
+        it("soft delete된 덱은 결과 키에서 제외된다") {
+            val userId = 1L
+            val preset = savePreset(userId = userId)
+            val deck = saveDeck(userId = userId, preset = preset)
+            deck.softDelete(deletedAt = Instant.now())
+            deckRepository.save(deck)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deck.id),
+            )
+
+            result.shouldBeEmpty()
+        }
+
+        it("빈 deckIds면 빈 맵을 반환한다") {
+            val userId = 1L
+            val preset = savePreset(userId = userId)
+            saveDeck(userId = userId, preset = preset)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = emptySet(),
+            )
+
+            result.shouldBeEmpty()
         }
     }
 

--- a/src/test/kotlin/com/whatever/caro/study/StudyTargetPoolCalculatorTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/StudyTargetPoolCalculatorTest.kt
@@ -1,8 +1,11 @@
 package com.whatever.caro.study
 
+import com.whatever.caro.study.internal.DeckCardCount
+import com.whatever.caro.study.internal.Sm2ParamsFixture
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -134,6 +137,142 @@ class StudyTargetPoolCalculatorTest :
                     repo.countTodayReviewCards(
                         userId = 1L,
                         deckId = 1L,
+                        nextSessionStart = LocalDateTime.parse(case.expectedNextSessionStart).atZone(case.timezone).toInstant(),
+                    )
+                }
+            }
+        }
+
+        describe("getTodayPools") {
+            it("덱별 카드 수가 perDay보다 많으면 perDay까지만, 적으면 카드 수 그대로 반환된다") {
+                val (calc, repo) = createCalculator()
+                val presetByDeckId = mapOf(
+                    1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 2, reviewPerDay = 1),
+                    2L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                )
+                every { repo.countNewCardsByDeckIds(any()) } returns
+                    listOf(DeckCardCount(1L, 5), DeckCardCount(2L, 4))
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns
+                    listOf(DeckCardCount(1L, 3), DeckCardCount(2L, 2))
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = presetByDeckId,
+                    dayCutoffHour = 0,
+                )
+
+                result[1L] shouldBe StudyTargetPoolCount(newCount = 2, reviewCount = 1)
+                result[2L] shouldBe StudyTargetPoolCount(newCount = 4, reviewCount = 2)
+            }
+
+            it("count 결과에 행이 없는 덱은 pool 0으로 폴백된다") {
+                val (calc, repo) = createCalculator()
+                val presetByDeckId = mapOf(
+                    1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                )
+                every { repo.countNewCardsByDeckIds(any()) } returns emptyList()
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns emptyList()
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = presetByDeckId,
+                    dayCutoffHour = 0,
+                )
+
+                result[1L] shouldBe StudyTargetPoolCount(newCount = 0, reviewCount = 0)
+            }
+
+            it("presetByDeckId가 비어있으면 count 쿼리 호출 없이 빈 맵을 반환한다") {
+                val (calc, repo) = createCalculator()
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = emptyMap(),
+                    dayCutoffHour = 0,
+                )
+
+                result.shouldBeEmpty()
+                verify(exactly = 0) { repo.countNewCardsByDeckIds(any()) }
+                verify(exactly = 0) { repo.countReviewCardsByDeckIds(any(), any()) }
+            }
+
+            it("반환된 키 집합은 presetByDeckId의 키 집합과 같다") {
+                val (calc, repo) = createCalculator()
+                val presetByDeckId = mapOf(
+                    1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE,
+                    2L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE,
+                    3L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE,
+                )
+                every { repo.countNewCardsByDeckIds(any()) } returns emptyList()
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns emptyList()
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = presetByDeckId,
+                    dayCutoffHour = 0,
+                )
+
+                result.keys shouldBe presetByDeckId.keys
+            }
+        }
+
+        describe("getTodayPools - 04시 기준 cutoff nextSessionStart 시간 계산 (단건과 동일 규칙)") {
+            data class BatchTimezoneCase(
+                val requestedAt: String,
+                val timezone: ZoneId,
+                val expectedNextSessionStart: String,
+                val label: String,
+            )
+
+            val cases = sequenceOf(
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-18T19:00:00",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 18일 19:00 요청일 경우, KST 19일 04:00이 다음 세션 시작 시간이다",
+                ),
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-19T03:59:59",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 19일 03:59:59 요청(컷오프 1초 직전)일 경우, KST 19일 04:00이 다음 세션 시작 시간이다",
+                ),
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-19T04:00:00",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-20T04:00:00",
+                    label = "KST 19일 04:00 요청(컷오프 정각)일 경우, KST 20일 04:00이 다음 세션 시작 시간이다",
+                ),
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-19T04:00:01",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-20T04:00:00",
+                    label = "KST 19일 04:00:01 요청(컷오프 1초 직후)일 경우, KST 20일 04:00이 다음 세션 시작 시간이다",
+                ),
+            )
+
+            withData(
+                nameFn = { it.label },
+                cases,
+            ) { case ->
+                val (calc, repo) = createCalculator()
+                every { repo.countNewCardsByDeckIds(any()) } returns emptyList()
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns emptyList()
+
+                calc.getTodayPools(
+                    now = LocalDateTime.parse(case.requestedAt).atZone(case.timezone).toInstant(),
+                    timezone = case.timezone,
+                    presetByDeckId = mapOf(1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE),
+                    dayCutoffHour = 4, // 해당 timezone의 04:00 cutoff
+                )
+
+                verify(exactly = 1) {
+                    repo.countReviewCardsByDeckIds(
+                        deckIds = setOf(1L),
                         nextSessionStart = LocalDateTime.parse(case.expectedNextSessionStart).atZone(case.timezone).toInstant(),
                     )
                 }

--- a/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
@@ -246,7 +246,7 @@ class EvaluationServiceTest(
                 log.easeFactor shouldBeGreaterThan cls.easeFactor
             }
 
-            it("마지막 카드 평가 시 estimatedTotal에 도달하면 세션이 COMPLETED 상태가 된다") {
+            it("마지막 카드 평가 시 목표치에 도달하면 세션이 COMPLETED 상태가 된다") {
                 stubPreset()
                 val session = createSession(newCardsGoal = 1, reviewCardsGoal = 0)
                 val cls = createCls(cardId = 1L, status = CardLearningStatus.NEW)
@@ -266,7 +266,7 @@ class EvaluationServiceTest(
                 reviewLogRepository.findAllByStudySessionId(session.id).size shouldBe 1
             }
 
-            it("estimatedTotal 미달 시 세션은 ACTIVE로 유지된다") {
+            it("목표치 미달 시 세션은 ACTIVE로 유지된다") {
                 stubPreset()
                 val session = createSession(newCardsGoal = 2, reviewCardsGoal = 0)
                 val cls = createCls(cardId = 1L, status = CardLearningStatus.NEW)

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceOnCardDeletionTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceOnCardDeletionTest.kt
@@ -1,0 +1,395 @@
+package com.whatever.caro.study.internal
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudySessionStatus
+import com.whatever.caro.study.StudyType
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import com.whatever.caro.study.internal.studysession.StudySession
+import com.whatever.caro.study.internal.studysession.StudySessionRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.modulith.test.ApplicationModuleTest
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+class StudyServiceOnCardDeletionTest(
+    private val studyService: StudyService,
+    private val studySessionRepository: StudySessionRepository,
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) : DescribeSpec({
+
+    val kstZoneId = ZoneId.of("Asia/Seoul")
+    val dayCutoffHour = 4
+    val baseNow: Instant = LocalDateTime.parse("2026-06-03T10:00:00").atZone(kstZoneId).toInstant()
+    val yesterday: Instant = baseNow.minus(1, ChronoUnit.DAYS)
+
+    afterTest {
+        studySessionRepository.deleteAllInBatch()
+        cardLearningStateRepository.deleteAllInBatch()
+    }
+
+    fun createSession(
+        userId: Long = USER_ID,
+        deckId: Long = DECK_ID,
+        status: StudySessionStatus = StudySessionStatus.ACTIVE,
+        startedAt: Instant = baseNow,
+        newCardsGoal: Int = 10,
+        reviewCardsGoal: Int = 10,
+        newCardsStudied: Int = 0,
+        reviewCardsStudied: Int = 0,
+    ): StudySession =
+        studySessionRepository.save(
+            StudySession(
+                userId = userId,
+                deckId = deckId,
+                status = status,
+                studyType = StudyType.DAILY,
+                startedAt = startedAt,
+                timezone = kstZoneId,
+                dayCutoffHour = dayCutoffHour,
+                deckPresetIdSnapshot = 1L,
+                newCardsStudied = newCardsStudied,
+                reviewCardsStudied = reviewCardsStudied,
+                newCardsGoal = newCardsGoal,
+                reviewCardsGoal = reviewCardsGoal,
+                endedAt = baseNow.takeIf { status == StudySessionStatus.COMPLETED },
+            ),
+        )
+
+    fun createCls(
+        cardId: Long,
+        userId: Long = USER_ID,
+        deckId: Long = DECK_ID,
+        status: CardLearningStatus = CardLearningStatus.NEW,
+        intervalDays: Int = 0,
+        easeFactor: BigDecimal = BigDecimal("2.50"),
+        repetitions: Int = 0,
+        lapses: Int = 0,
+        consecutiveAgainCount: Int = 0,
+        lastReviewedAt: Instant? = null,
+        nextReviewAt: Instant? = null,
+    ): CardLearningState =
+        cardLearningStateRepository.save(
+            CardLearningState(
+                cardId = cardId,
+                deckId = deckId,
+                userId = userId,
+                status = status,
+                intervalDays = intervalDays,
+                easeFactor = easeFactor,
+                repetitions = repetitions,
+                lapses = lapses,
+                consecutiveAgainCount = consecutiveAgainCount,
+                lastReviewedAt = lastReviewedAt,
+                nextReviewAt = nextReviewAt,
+            ),
+        )
+
+    describe("adjustGoalsOnCardDeletion") {
+        context("ACTIVE 상태인 오늘 세션이 아니면 아무것도 변경하지 않는다") {
+
+            it("COMPLETED 세션이면 상태를 변경하지 않는다") {
+                val session = createSession(
+                    status = StudySessionStatus.COMPLETED,
+                    newCardsGoal = 5,
+                    newCardsStudied = 0,
+                    reviewCardsGoal = 5,
+                    reviewCardsStudied = 0,
+                )
+                // CLS 0장 → ACTIVE였다면 recalculateGoals(0,0)로 goal이 5,5 → 0,0까지 떨어질 조건
+                // 하지만 COMPLETED이므로 early-return되어 5,5 그대로여야 한다
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                persisted.newCardsGoal shouldBe 5
+                persisted.reviewCardsGoal shouldBe 5
+                persisted.status shouldBe StudySessionStatus.COMPLETED
+            }
+
+            it("STOPPED 세션이면 상태를 변경하지 않는다") {
+                val session = createSession(
+                    status = StudySessionStatus.STOPPED,
+                    newCardsGoal = 5,
+                    newCardsStudied = 0,
+                    reviewCardsGoal = 5,
+                    reviewCardsStudied = 0,
+                )
+                // CLS 0장 → ACTIVE였다면 recalculateGoals(0,0)로 goal이 5,5 → 0,0까지 떨어질 조건
+                // 하지만 STOPPED이므로 early-return되어 5,5 그대로여야 한다
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                persisted.status shouldBe StudySessionStatus.STOPPED
+                persisted.newCardsGoal shouldBe 5
+                persisted.reviewCardsGoal shouldBe 5
+            }
+
+            it("오늘이 아닌 ACTIVE 세션이면 상태를 변경하지 않는다") {
+                val session = createSession(
+                    status = StudySessionStatus.ACTIVE,
+                    startedAt = yesterday,
+                    newCardsGoal = 5,
+                    reviewCardsGoal = 5,
+                )
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                persisted.newCardsGoal shouldBe 5
+                persisted.reviewCardsGoal shouldBe 5
+                persisted.startedAt shouldBe yesterday
+            }
+
+            it("세션이 없으면 아무 일도 발생하지 않는다") {
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                studySessionRepository.findAll() shouldBe emptyList()
+            }
+        }
+
+        context("adjustGoalsOnCardDeletion의 available 카드 계산") {
+
+            it("세션 중 평가된(lastReviewedAt이 sessionStart 이후) NEW 카드는 availableNew에서 제외된다") {
+                val session = createSession(
+                    newCardsGoal = 5,
+                    newCardsStudied = 2,
+                )
+                // 처음 학습하는 카드와 어제 학습했던 카드이기 때문에 availableNew에 포함되는 카드 2장
+                createCls(cardId = 1L, status = CardLearningStatus.NEW, lastReviewedAt = null)
+                createCls(cardId = 2L, status = CardLearningStatus.NEW, lastReviewedAt = session.sessionStart.minus(1, ChronoUnit.DAYS))
+
+                // availableNew에서 제외되는 카드 1장 (lastReviewedAt >= sessionStart)
+                createCls(
+                    cardId = 3L,
+                    status = CardLearningStatus.NEW,
+                    lastReviewedAt = session.sessionStart.plus(1, ChronoUnit.MINUTES),
+                )
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                // newGoal = min(5, 2+2) = 4
+                persisted.newCardsGoal shouldBe 4
+                persisted.status shouldBe StudySessionStatus.ACTIVE
+            }
+
+            it("이미 softDelete된 CLS는 availableReview에서 제외된다") {
+                val session = createSession(
+                    reviewCardsGoal = 5,
+                    reviewCardsStudied = 2,
+                )
+                // availableReview에 포함되는 REVIEW 4장 생성
+                val reviewCards = (1..4).map { i ->
+                    createCls(
+                        i.toLong(),
+                        status = CardLearningStatus.REVIEW,
+                        nextReviewAt = session.nextSessionStart.minusSeconds(1),
+                    )
+                }
+                // 3장 softDelete, availableReview에 포함될 수 있는 카드는 1장
+                reviewCards.take(3).forEach { cls ->
+                    cls.softDelete(deletedAt = baseNow)
+                }
+                cardLearningStateRepository.saveAll(reviewCards)
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                // reviewGoal = min(5, 2+1) = 3
+                persisted.reviewCardsGoal shouldBe 3
+            }
+
+            it("이미 softDelete된 NEW 카드는 availableNew에서 제외된다") {
+                val session = createSession(
+                    newCardsGoal = 5,
+                    newCardsStudied = 2,
+                )
+                // availableNew에 포함되는 NEW 카드 2장
+                createCls(cardId = 1L, status = CardLearningStatus.NEW)
+                createCls(cardId = 2L, status = CardLearningStatus.NEW)
+                // softDelete된 NEW 카드 1장은 availableNew에서 제외
+                createCls(cardId = 3L, status = CardLearningStatus.NEW).apply {
+                    softDelete(deletedAt = baseNow)
+                    cardLearningStateRepository.save(this)
+                }
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                // newGoal = min(5, 2+2) = 4
+                persisted.newCardsGoal shouldBe 4
+                persisted.status shouldBe StudySessionStatus.ACTIVE
+            }
+
+            it("오늘 세션에 포함되지 않는(nextReviewAt이 다음 세션의 시작 시간과 같은) 경우 REVIEW 카드는 availableReview에서 제외된다") {
+                // [sessionStart, sessionEnd] < card.nextReviewAt
+                val s = createSession(
+                    reviewCardsGoal = 5,
+                    reviewCardsStudied = 0,
+                )
+                // 오늘 세션에 포함되어 availableReview에 포함되는 카드
+                createCls(
+                    30L,
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = s.nextSessionStart.minusSeconds(1),
+                )
+                // 다음 세션에 복습 대상이므로 포함 안되는 카드
+                createCls(
+                    31L,
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = s.nextSessionStart,
+                )
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(s.id)!!
+                // reviewGoal = min(5, 0+1) = 1
+                persisted.reviewCardsGoal shouldBe 1
+                persisted.status shouldBe StudySessionStatus.ACTIVE
+            }
+
+            it("이번 세션의 경계에 학습한(lastReviewedAt이 sessionStart 정각인) NEW 카드는 availableNew에서 제외된다") {
+                // card.lastReviewedAt <= [sessionStart, sessionEnd]
+                val session = createSession(
+                    newCardsGoal = 5,
+                    newCardsStudied = 0,
+                )
+                // 이번 세션 1초 전에 학습합 NEW 카드는 이전 세션에 포함되므로 availableNew에 포함
+                createCls(
+                    cardId = 1L,
+                    status = CardLearningStatus.NEW,
+                    lastReviewedAt = session.sessionStart.minusSeconds(1),
+                )
+                // 이번 세션의 시작 경계에 학습한 카드는 같은 세션 학습이므로 제외
+                createCls(
+                    cardId = 2L,
+                    status = CardLearningStatus.NEW,
+                    lastReviewedAt = session.sessionStart,
+                )
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                // newGoal = min(5, 0+1) = 1
+                persisted.newCardsGoal shouldBe 1
+                persisted.status shouldBe StudySessionStatus.ACTIVE
+            }
+
+            it("다른 deck이나 다른 user의 카드는 available 대상에 포함되지 않는다") {
+                val session = createSession(
+                    newCardsGoal = 5,
+                    newCardsStudied = 0,
+                    reviewCardsGoal = 5,
+                    reviewCardsStudied = 0,
+                )
+                // 내 deck의 학습 대상 카드: NEW 1장, REVIEW 1장
+                createCls(cardId = 1L, status = CardLearningStatus.NEW)
+                createCls(
+                    cardId = 2L,
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = session.nextSessionStart.minusSeconds(1),
+                )
+                // 다른 deck의 카드는 제외
+                createCls(cardId = 3L, deckId = 2L, status = CardLearningStatus.NEW)
+                createCls(
+                    cardId = 4L,
+                    deckId = 2L,
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = session.nextSessionStart.minusSeconds(1),
+                )
+                // 다른 user의 카드는 제외
+                createCls(cardId = 5L, userId = 2L, status = CardLearningStatus.NEW)
+                createCls(
+                    cardId = 6L,
+                    userId = 2L,
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = session.nextSessionStart.minusSeconds(1),
+                )
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                // 내 deck 카드만 계산되므로
+                persisted.newCardsGoal shouldBe 1 // newGoal = min(5, 0+1) = 1
+                persisted.reviewCardsGoal shouldBe 1 // reviewGoal = min(5, 0+1) = 1
+                persisted.status shouldBe StudySessionStatus.ACTIVE
+            }
+        }
+
+        context("목표 조정 후 결과 확인") {
+
+            it("후보가 부족하면 review goal이 감소한다") {
+                val session = createSession(
+                    reviewCardsGoal = 10,
+                    reviewCardsStudied = 5,
+                )
+                // 학습해야할 남은 REVIEW 4장
+                repeat(4) { i ->
+                    createCls(
+                        i.toLong(),
+                        status = CardLearningStatus.REVIEW,
+                        nextReviewAt = session.nextSessionStart.minusSeconds(1),
+                    )
+                }
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                // reviewGoal = min(10, 5+4) = 9
+                persisted.reviewCardsGoal shouldBe 9
+                persisted.status shouldBe StudySessionStatus.ACTIVE
+            }
+
+            it("후보가 전부 사라지면 goal이 studied로 내려가 세션이 COMPLETED 된다") {
+                val session = createSession(
+                    newCardsGoal = 10,
+                    newCardsStudied = 5,
+                    reviewCardsGoal = 10,
+                    reviewCardsStudied = 5,
+                )
+                // 학습 가능한 카드 0장
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                persisted.status shouldBe StudySessionStatus.COMPLETED
+                persisted.endedAt shouldBe baseNow
+                persisted.newCardsGoal shouldBe 5
+                persisted.reviewCardsGoal shouldBe 5
+            }
+
+            it("studied가 0인 채 후보가 전부 사라지면 goal이 0,0이 되어 세션이 COMPLETED 된다") {
+                val session = createSession(
+                    newCardsGoal = 3,
+                    newCardsStudied = 0,
+                    reviewCardsGoal = 3,
+                    reviewCardsStudied = 0,
+                )
+                // 학습 가능한 카드 0장
+
+                studyService.adjustGoalsOnCardDeletion(now = baseNow, userId = USER_ID, deckId = DECK_ID)
+
+                val persisted = studySessionRepository.findByIdOrNull(session.id)!!
+                persisted.status shouldBe StudySessionStatus.COMPLETED
+                persisted.newCardsGoal shouldBe 0
+                persisted.reviewCardsGoal shouldBe 0
+            }
+        }
+    }
+}) {
+    companion object {
+        private const val USER_ID = 1L
+        private const val DECK_ID = 1L
+    }
+}

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
@@ -301,6 +301,259 @@ class StudyServiceTest(
         }
     }
 
+    describe("getTodaySummaries") {
+
+        it("ACTIVE 상태인 오늘 세션이 있는 덱은 InProgress로 반환된다") {
+            val session = createSession(
+                status = StudySessionStatus.ACTIVE,
+                newStudied = 3,
+                reviewStudied = 5,
+            )
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val inProgress = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.InProgress>()
+            inProgress.session.sessionId shouldBe session.id
+            inProgress.session.newCardsStudied shouldBe 3
+            inProgress.session.reviewCardsStudied shouldBe 5
+            inProgress.session.estimatedTotal shouldBe (session.newCardsGoal + session.reviewCardsGoal)
+        }
+
+        it("COMPLETED 상태인 오늘 세션이 있는 덱은 Completed로 반환된다") {
+            val session = createSession(
+                status = StudySessionStatus.COMPLETED,
+                newStudied = 10,
+                reviewStudied = 10,
+            )
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val completed = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.Completed>()
+            completed.session.sessionId shouldBe session.id
+        }
+
+        it("어제의 ACTIVE 세션은 무시하고 pool 경로로 판정한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 5, reviewPerDay = 0))
+            createSession(status = StudySessionStatus.ACTIVE, startedAt = yesterday)
+            repeat(2) { i ->
+                createCls(cardId = (i + 1).toLong(), status = CardLearningStatus.NEW)
+            }
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val notStarted = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            notStarted.pool.newCount shouldBe 2
+        }
+
+        it("오늘 세션이라도 STOPPED 상태면 세션 없음으로 취급한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 0, reviewPerDay = 0))
+            createSession(status = StudySessionStatus.STOPPED, startedAt = baseNow)
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            result[DECK_ID] shouldBe TodayStudySessionState.RestDay
+        }
+
+        it("세션이 없고 학습 대상 카드가 있으면 정확한 pool 값의 NotStarted를 반환한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10))
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), status = CardLearningStatus.NEW)
+            }
+            repeat(2) { i ->
+                createCls(
+                    cardId = (100 + i).toLong(),
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = baseNow,
+                )
+            }
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val notStarted = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            notStarted.pool.newCount shouldBe 3
+            notStarted.pool.reviewCount shouldBe 2
+            notStarted.presetId shouldBe Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.id
+        }
+
+        it("세션이 없고 학습 대상 카드도 없으면 RestDay를 반환한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10))
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            result[DECK_ID] shouldBe TodayStudySessionState.RestDay
+        }
+
+        it("학습 대상 카드 수가 preset의 perDay를 넘으면 perDay까지만 pool에 담긴다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 2, reviewPerDay = 1))
+            repeat(5) { i ->
+                createCls(cardId = (i + 1).toLong(), status = CardLearningStatus.NEW)
+            }
+            repeat(3) { i ->
+                createCls(
+                    cardId = (100 + i).toLong(),
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = baseNow,
+                )
+            }
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val notStarted = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            notStarted.pool.newCount shouldBe 2
+            notStarted.pool.reviewCount shouldBe 1
+        }
+
+        it("여러 덱의 상태가 혼합되어도 입력한 모든 deckId가 결과 키로 반환된다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(
+                    3L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                    4L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                )
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE)
+            createSession(deckId = 2L, status = StudySessionStatus.COMPLETED)
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), deckId = 3L, status = CardLearningStatus.NEW)
+            }
+            // deckId=4L는 세션도 카드도 없음
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L, 3L, 4L),
+            )
+
+            result.keys shouldBe setOf(1L, 2L, 3L, 4L)
+            result[1L].shouldBeInstanceOf<TodayStudySessionState.InProgress>()
+            result[2L].shouldBeInstanceOf<TodayStudySessionState.Completed>()
+            result[3L].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            result[4L] shouldBe TodayStudySessionState.RestDay
+        }
+
+        it("모든 덱에 오늘 세션이 있으면 preset 배치 조회를 호출하지 않는다") {
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE)
+            createSession(deckId = 2L, status = StudySessionStatus.COMPLETED)
+
+            studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L),
+            )
+
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) }
+        }
+
+        it("세션이 없는 덱이 있어도 단건 preset 조회는 호출하지 않는다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(2L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 0, reviewPerDay = 0))
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE)
+
+            studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L),
+            )
+
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetByUser(any(), any()) }
+        }
+
+        it("같은 데이터에 대해 단건 getTodaySummary와 동일한 결과를 반환한다") {
+            val preset = Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10)
+            every { deckPresetApi.getLatestDeckPresetByUser(any(), any()) } returns preset
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(2L to preset, 3L to preset)
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE, newStudied = 3) // InProgress
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), deckId = 2L, status = CardLearningStatus.NEW) // NotStarted
+            }
+            // deckId=3L는 세션도 카드도 없음 → RestDay
+
+            val batchResult = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L, 3L),
+            )
+
+            listOf(1L, 2L, 3L).forEach { deckId ->
+                batchResult[deckId] shouldBe studyService.getTodaySummary(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    deckId = deckId,
+                )
+            }
+        }
+
+        it("세션이 없는 덱에 preset이 연결되어 있지 않으면 IllegalStateException을 던진다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns emptyMap()
+
+            shouldThrow<IllegalStateException> {
+                studyService.getTodaySummaries(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    deckIds = setOf(DECK_ID),
+                )
+            }
+        }
+
+        it("deckIds가 비어있으면 외부 호출 없이 빈 맵을 반환한다") {
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = emptySet(),
+            )
+
+            result.shouldBeEmpty()
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) }
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetByUser(any(), any()) }
+        }
+    }
+
     describe("getLearningStates") {
 
         it("매칭되는 카드는 cardId 기준 맵으로 매핑되고, 매칭되지 않는 요소는 무시한다") {

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -200,7 +200,7 @@ class CardLearningStateRepositoryTest(
             )
             val cardIds = clsList.map { it.cardId }
 
-            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
                 userId = clsList.first().userId,
                 cardIds = cardIds,
             )
@@ -215,7 +215,7 @@ class CardLearningStateRepositoryTest(
                 nextReviewAt = beforeCutoff,
             )
 
-            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
                 userId = 1L,
                 cardIds = listOf(cls.cardId),
             )
@@ -229,7 +229,7 @@ class CardLearningStateRepositoryTest(
                 nextReviewAt = beforeCutoff,
             )
 
-            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
                 userId = cls.userId,
                 cardIds = emptyList(),
             )
@@ -243,7 +243,7 @@ class CardLearningStateRepositoryTest(
                 nextReviewAt = beforeCutoff,
             )
 
-            val result = cardLearningStateRepository.findAllByUserIdAndCardIdIn(
+            val result = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(
                 userId = cls.userId,
                 cardIds = listOf(cls.cardId, 2L),
             )

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -371,4 +371,76 @@ class CardLearningStateRepositoryTest(
             count shouldBe 1
         }
     }
+
+    // TODO userId 필터 추가 시 격리 케이스 추가
+    describe("countNewCardsByDeckIds") {
+        it("덱별 NEW 카드 수가 deckId 기준으로 집계된다") {
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), deckId = 1L, status = CardLearningStatus.NEW)
+            }
+            repeat(5) { i ->
+                createCls(cardId = (10 + i + 1).toLong(), deckId = 2L, status = CardLearningStatus.NEW)
+            }
+
+            val result = cardLearningStateRepository.countNewCardsByDeckIds(
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 3L, 2L to 5L)
+        }
+
+        it("NEW 카드가 없는 덱은 결과에 행 자체가 없다") {
+            createCls(cardId = 1L, deckId = 1L, status = CardLearningStatus.NEW)
+
+            val result = cardLearningStateRepository.countNewCardsByDeckIds(
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.map { it.deckId } shouldBe listOf(1L)
+        }
+
+        it("REVIEW 상태 카드와 soft delete된 NEW 카드는 집계되지 않는다") {
+            createCls(cardId = 1L, deckId = 1L, status = CardLearningStatus.NEW)
+            createCls(cardId = 2L, deckId = 1L, status = CardLearningStatus.REVIEW, nextReviewAt = beforeCutoff)
+            val deleted = createCls(cardId = 3L, deckId = 1L, status = CardLearningStatus.NEW)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.countNewCardsByDeckIds(
+                deckIds = setOf(1L),
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
+        }
+    }
+
+    // TODO userId 필터 추가 시 격리 케이스 추가
+    describe("countReviewCardsByDeckIds") {
+        it("nextReviewAt이 nextSessionStart 직전(1초 전)인 카드는 포함되고, 동일한 카드는 제외된다") {
+            createCls(cardId = 1L, deckId = 1L, nextReviewAt = nextSessionStart.minusSeconds(1))
+            createCls(cardId = 2L, deckId = 2L, nextReviewAt = nextSessionStart)
+
+            val result = cardLearningStateRepository.countReviewCardsByDeckIds(
+                deckIds = setOf(1L, 2L),
+                nextSessionStart = nextSessionStart,
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
+        }
+
+        it("NEW 상태 카드와 soft delete된 REVIEW 카드는 집계되지 않는다") {
+            createCls(cardId = 1L, deckId = 1L, nextReviewAt = beforeCutoff)
+            createCls(cardId = 2L, deckId = 1L, status = CardLearningStatus.NEW, nextReviewAt = beforeCutoff)
+            val deleted = createCls(cardId = 3L, deckId = 1L, nextReviewAt = beforeCutoff)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.countReviewCardsByDeckIds(
+                deckIds = setOf(1L),
+                nextSessionStart = nextSessionStart,
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
+        }
+    }
 })

--- a/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
@@ -3,20 +3,28 @@ package com.whatever.caro.study.internal.event
 import com.whatever.caro.TestcontainersConfiguration
 import com.whatever.caro.card.api.event.CardsDeletedEvent
 import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudySessionStatus
+import com.whatever.caro.study.StudyType
 import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import com.whatever.caro.study.internal.studysession.StudySession
+import com.whatever.caro.study.internal.studysession.StudySessionRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.inspectors.forAll
-import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
 import org.awaitility.Awaitility.await
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.modulith.test.ApplicationModuleTest
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 @ApplicationModuleTest(extraIncludes = ["common"])
@@ -25,8 +33,11 @@ class CardLearningStateEventListenerTest(
     private val transactionTemplate: TransactionTemplate,
     private val publisher: ApplicationEventPublisher,
     private val cardLearningStateRepository: CardLearningStateRepository,
+    private val studySessionRepository: StudySessionRepository,
     private val clock: Clock,
 ) : DescribeSpec({
+
+    val kstZoneId = ZoneId.of("Asia/Seoul")
 
     fun createCls(
         cardId: Long,
@@ -57,27 +68,181 @@ class CardLearningStateEventListenerTest(
             ),
         )
 
+    fun createSession(
+        status: StudySessionStatus = StudySessionStatus.ACTIVE,
+        startedAt: Instant,
+        newCardsGoal: Int,
+        reviewCardsGoal: Int,
+        newCardsStudied: Int = 0,
+        reviewCardsStudied: Int = 0,
+    ): StudySession =
+        studySessionRepository.save(
+            StudySession(
+                userId = 1L,
+                deckId = 1L,
+                status = status,
+                studyType = StudyType.DAILY,
+                startedAt = startedAt,
+                timezone = kstZoneId,
+                dayCutoffHour = 4,
+                deckPresetIdSnapshot = 1L,
+                newCardsStudied = newCardsStudied,
+                reviewCardsStudied = reviewCardsStudied,
+                newCardsGoal = newCardsGoal,
+                reviewCardsGoal = reviewCardsGoal,
+            ),
+        )
+
+    afterTest {
+        studySessionRepository.deleteAllInBatch()
+        cardLearningStateRepository.deleteAllInBatch()
+    }
+
     describe("onCardDeleted") {
         it("CardsDeletedEvent를 수신하면 LearningState를 softdelete한다") {
             val cardIds = (1L..10L).toSet()
             val learningStates = cardIds.map { cardId -> createCls(cardId) }
+            val deletedAt = Instant.now(clock)
+            transactionTemplate.execute {
+                publisher.publishEvent(
+                    CardsDeletedEvent(
+                        deckId = 1L,
+                        deletedCount = cardIds.size,
+                        userId = 1L,
+                        deletedCardIds = cardIds,
+                        deletedAt = deletedAt,
+                    ),
+                )
+            }
+
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                val deletedLearningStates = cardLearningStateRepository.findAllById(learningStates.map { it.id })
+                deletedLearningStates.forAll {
+                    it.deletedAt shouldBe deletedAt
+                }
+                deletedLearningStates.map { it.cardId } shouldContainExactlyInAnyOrder cardIds
+            }
+        }
+
+        it("카드 삭제 이벤트를 받으면 CLS softDelete와 세션 goal 재계산이 함께 일어난다") {
+            val now = Instant.now(clock)
+            val session = createSession(
+                startedAt = now,
+                newCardsGoal = 0,
+                reviewCardsGoal = 5,
+                reviewCardsStudied = 2,
+            )
+            val clsList = (0L..2L).map { i ->
+                createCls(
+                    cardId = i,
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = session.nextSessionStart.minusSeconds(1),
+                )
+            }
+            studySessionRepository.findByIdOrNull(session.id)!!.status shouldBe StudySessionStatus.ACTIVE
+
+            transactionTemplate.execute {
+                publisher.publishEvent(
+                    CardsDeletedEvent(
+                        deckId = 1L,
+                        deletedCount = 3,
+                        userId = 1L,
+                        deletedCardIds = clsList.map { it.cardId }.toSet(), // 모든 cls 삭제
+                        deletedAt = now,
+                    ),
+                )
+            }
+
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                clsList.map { it.id }.let { ids ->
+                    cardLearningStateRepository.findAllById(ids).forAll {
+                        it.deletedAt shouldBe now
+                    }
+                }
+                // goal이 5에서 감소 (정확한 수치와 COMPLETED 상태 변경 규칙은 엔티티/서비스 계층 테스트에서 진행)
+                studySessionRepository.findByIdOrNull(session.id)!!.reviewCardsGoal shouldBeLessThan 5
+            }
+        }
+
+        it("삭제된 카드에 대한 학습상태가 없으면 아무 변화가 없어야한다") {
+            val now = Instant.now(clock)
+            val initialReviewCardsGoal = 5
+            val session = createSession(
+                startedAt = now,
+                newCardsGoal = 0,
+                reviewCardsGoal = initialReviewCardsGoal,
+                reviewCardsStudied = 2,
+            )
+            // 내 ACTIVE 오늘 세션이 있으므로, adjustGoals까지 진행됐다면 goal이 min(5, 2+0)=2로 감소해야함
+
             transactionTemplate.execute {
                 publisher.publishEvent(
                     CardsDeletedEvent(
                         deckId = 1L,
                         deletedCount = 1,
                         userId = 1L,
-                        deletedCardIds = cardIds,
-                        deletedAt = Instant.now(clock),
+                        deletedCardIds = setOf(999L),
+                        deletedAt = now,
                     ),
                 )
             }
 
             await().atMost(2, TimeUnit.SECONDS).untilAsserted {
-                cardLearningStateRepository.findAllById(learningStates.map { it.id }).forAll {
-                    it.deletedAt.shouldNotBeNull()
+                studySessionRepository.findByIdOrNull(session.id)!!.let {
+                    it.status shouldBe StudySessionStatus.ACTIVE
+                    it.reviewCardsGoal shouldBe initialReviewCardsGoal
                 }
             }
+        }
+
+        it("같은 삭제 이벤트가 중복 전달되어도 첫 softDelete의 deletedAt이 유지된다") {
+            val firstDeletedAt = Instant.now(clock)
+            val cls = createCls(cardId = 200L)
+            val event = CardsDeletedEvent(
+                deckId = 1L,
+                deletedCount = 1,
+                userId = 1L,
+                deletedCardIds = setOf(cls.cardId),
+                deletedAt = firstDeletedAt,
+            )
+
+            transactionTemplate.execute {
+                publisher.publishEvent(event)
+            }
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                val deletedCls = cardLearningStateRepository.findByIdOrNull(cls.id)!!
+                deletedCls.deletedAt shouldBe firstDeletedAt
+            }
+
+            val secondDeletedAt = firstDeletedAt.plusSeconds(60)
+            transactionTemplate.execute {
+                publisher.publishEvent(event.copy(deletedAt = secondDeletedAt))
+            }
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                val deletedCls = cardLearningStateRepository.findByIdOrNull(cls.id)!!
+                deletedCls.deletedAt shouldBe firstDeletedAt
+            }
+        }
+
+        it("발행 트랜잭션이 롤백되면 리스너가 실행되지 않는다") {
+            val now = Instant.now(clock)
+            val cls = createCls(cardId = 300L)
+
+            transactionTemplate.execute { status ->
+                publisher.publishEvent(
+                    CardsDeletedEvent(
+                        deckId = 1L,
+                        deletedCount = 1,
+                        userId = 1L,
+                        deletedCardIds = setOf(cls.cardId),
+                        deletedAt = now,
+                    ),
+                )
+                status.setRollbackOnly()
+            }
+
+            val savedCls = cardLearningStateRepository.findByIdOrNull(cls.id)!!
+            savedCls.deletedAt shouldBe null
         }
     }
 })

--- a/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
@@ -1,0 +1,80 @@
+package com.whatever.caro.study.internal.event
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.card.api.event.CardsDeletedEvent
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.internal.MockDeckPresetApiConfig
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.nulls.shouldNotBeNull
+import org.awaitility.Awaitility.await
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Import
+import org.springframework.modulith.test.ApplicationModuleTest
+import org.springframework.transaction.support.TransactionTemplate
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+class CardLearningStateEventListenerTest(
+    private val transactionTemplate: TransactionTemplate,
+    private val publisher: ApplicationEventPublisher,
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) : DescribeSpec({
+
+    fun createCls(
+        cardId: Long,
+        userId: Long = 1L,
+        deckId: Long = 1L,
+        status: CardLearningStatus = CardLearningStatus.NEW,
+        intervalDays: Int = 0,
+        easeFactor: BigDecimal = BigDecimal("2.50"),
+        repetitions: Int = 0,
+        lapses: Int = 0,
+        consecutiveAgainCount: Int = 0,
+        lastReviewedAt: Instant? = null,
+        nextReviewAt: Instant? = null,
+    ): CardLearningState =
+        cardLearningStateRepository.save(
+            CardLearningState(
+                cardId = cardId,
+                deckId = deckId,
+                userId = userId,
+                status = status,
+                intervalDays = intervalDays,
+                easeFactor = easeFactor,
+                repetitions = repetitions,
+                lapses = lapses,
+                consecutiveAgainCount = consecutiveAgainCount,
+                lastReviewedAt = lastReviewedAt,
+                nextReviewAt = nextReviewAt,
+            ),
+        )
+
+    describe("onCardDeleted") {
+        it("CardsDeletedEvent를 수신하면 LearningState를 softdelete한다") {
+            val cardIds = (1L..10L).toSet()
+            val learningStates = cardIds.map { cardId -> createCls(cardId) }
+            transactionTemplate.execute {
+                publisher.publishEvent(
+                    CardsDeletedEvent(
+                        deckId = 1L,
+                        deletedCount = 1,
+                        userId = 1L,
+                        deletedCardIds = cardIds,
+                    ),
+                )
+            }
+
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                cardLearningStateRepository.findAllById(learningStates.map { it.id }).forAll {
+                    it.deletedAt.shouldNotBeNull()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
+import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -24,6 +25,7 @@ class CardLearningStateEventListenerTest(
     private val transactionTemplate: TransactionTemplate,
     private val publisher: ApplicationEventPublisher,
     private val cardLearningStateRepository: CardLearningStateRepository,
+    private val clock: Clock,
 ) : DescribeSpec({
 
     fun createCls(
@@ -66,6 +68,7 @@ class CardLearningStateEventListenerTest(
                         deletedCount = 1,
                         userId = 1L,
                         deletedCardIds = cardIds,
+                        deletedAt = Instant.now(clock),
                     ),
                 )
             }

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
@@ -5,11 +5,13 @@ import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
 import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 @ApplicationModuleTest(extraIncludes = ["common"])
 @Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
@@ -23,16 +25,20 @@ class StudySessionRepositoryTest(
 
     fun saveSession(
         status: StudySessionStatus = StudySessionStatus.ACTIVE,
+        userId: Long = 1L,
+        deckId: Long = 1L,
+        startedAt: Instant = now,
+        dayCutoffHour: Int = 4,
     ): StudySession =
         studySessionRepository.save(
             StudySession(
-                userId = 1L,
-                deckId = 1L,
+                userId = userId,
+                deckId = deckId,
                 status = status,
                 studyType = StudyType.DAILY,
-                startedAt = now,
+                startedAt = startedAt,
                 timezone = kstZoneId,
-                dayCutoffHour = 4,
+                dayCutoffHour = dayCutoffHour,
                 deckPresetIdSnapshot = 1L,
             ),
         )
@@ -54,6 +60,73 @@ class StudySessionRepositoryTest(
 
             affected shouldBe 0
             studySessionRepository.findById(session.id).orElseThrow().status shouldBe StudySessionStatus.COMPLETED
+        }
+    }
+
+    describe("findLatestByUserIdAndDeckIdIn") {
+        val yesterday = now.minus(1, ChronoUnit.DAYS)
+
+        it("덱별로 startedAt이 가장 최신인 세션 1건씩만 반환한다") {
+            saveSession(deckId = 1L, startedAt = yesterday)
+            val latestOfDeck1 = saveSession(deckId = 1L, startedAt = now)
+            saveSession(deckId = 2L, startedAt = yesterday)
+            val latestOfDeck2 = saveSession(deckId = 2L, startedAt = now)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.map { it.id }.shouldContainExactlyInAnyOrder(listOf(latestOfDeck1.id, latestOfDeck2.id))
+        }
+
+        it("같은 덱에 startedAt이 동일한 세션이 여러 건이면 id가 큰 세션만 반환한다") {
+            // uk_session_per_day(user, deck, session_date) 때문에 같은 날짜의 동률은 존재할 수 없어,
+            // dayCutoffHour를 다르게 줘서 session_date가 갈리는 startedAt 동률을 재현한다
+            saveSession(deckId = 1L, startedAt = now, dayCutoffHour = 11)
+            val laterInserted = saveSession(deckId = 1L, startedAt = now, dayCutoffHour = 4)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L),
+            )
+
+            result.map { it.id } shouldBe listOf(laterInserted.id)
+        }
+
+        it("다른 userId의 같은 deckId 세션은 더 최신이어도 결과에 영향을 주지 않는다") {
+            val mySession = saveSession(userId = 1L, deckId = 1L, startedAt = yesterday)
+            saveSession(userId = 2L, deckId = 1L, startedAt = now)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L),
+            )
+
+            result.map { it.id } shouldBe listOf(mySession.id)
+        }
+
+        it("deckIds에 포함되지 않은 덱의 세션은 반환되지 않는다") {
+            val sessionOfDeck1 = saveSession(deckId = 1L)
+            saveSession(deckId = 2L)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L),
+            )
+
+            result.map { it.id } shouldBe listOf(sessionOfDeck1.id)
+        }
+
+        it("세션이 없는 덱은 결과에 행 자체가 없다") {
+            saveSession(deckId = 1L)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.map { it.deckId } shouldBe listOf(1L)
         }
     }
 })

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
@@ -4,6 +4,7 @@ import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.LocalDateTime
@@ -16,7 +17,12 @@ class StudySessionTest :
         // 산식: isTodaySession(now) = (sessionDate == now.atZone(KST).minusHours(4).toLocalDate())
         // sessionDate=2026-05-18 기준으로 "now가 cutoff 04:00 직전인지" 경계 검증
 
-        fun createSession(): StudySession =
+        fun createSession(
+            newCardsGoal: Int = 0,
+            newCardsStudied: Int = 0,
+            reviewCardsGoal: Int = 0,
+            reviewCardsStudied: Int = 0,
+        ): StudySession =
             StudySession(
                 userId = 1L,
                 deckId = 1L,
@@ -26,6 +32,10 @@ class StudySessionTest :
                 timezone = kstZoneId,
                 dayCutoffHour = dayCutoffHour,
                 deckPresetIdSnapshot = 1L,
+                newCardsGoal = newCardsGoal,
+                newCardsStudied = newCardsStudied,
+                reviewCardsGoal = reviewCardsGoal,
+                reviewCardsStudied = reviewCardsStudied,
             )
 
         describe("isTodaySession - KST cutoff=04:00 경계 (sessionDate=2026-05-18 기준)") {
@@ -66,6 +76,86 @@ class StudySessionTest :
                 val session = createSession()
 
                 session.isTodaySession(now) shouldBe case.expected
+            }
+        }
+
+        describe("recalculateGoals") {
+            it("여유분이 부족하면 goal을 studied+available로 감소시키고, 충분하면 기존 goal을 상한으로 유지한다") {
+                val newCardsGoal = 10
+                val reviewCardsGoal = 10
+                val s = createSession(newCardsGoal = newCardsGoal, newCardsStudied = 5, reviewCardsGoal = reviewCardsGoal, reviewCardsStudied = 5)
+
+                val availableReviewGoal = 4
+                s.recalculateGoals(availableNewGoal = 100, availableReviewGoal = availableReviewGoal)
+
+                // review: min(10, 5+4) = 9, 여유분 부족하므로 감소
+                s.reviewCardsGoal shouldBe s.reviewCardsStudied + availableReviewGoal
+
+                // new: min(10, 5+100) = 10, 여유분 충분하므로 기존 goal 유지
+                s.newCardsGoal shouldBe newCardsGoal
+            }
+
+            it("available이 0이면 goal이 studied까지 내려간다") {
+                val s = createSession(newCardsGoal = 10, newCardsStudied = 4, reviewCardsGoal = 10, reviewCardsStudied = 4)
+
+                s.recalculateGoals(availableNewGoal = 0, availableReviewGoal = 0)
+
+                // min(10, 4+0) = 4
+                s.newCardsGoal shouldBe 4
+                s.reviewCardsGoal shouldBe 4
+            }
+
+            it("studied가 이미 goal을 초과해도 goal은 변하지 않는다") {
+                val s = createSession(newCardsGoal = 5, newCardsStudied = 7, reviewCardsGoal = 5, reviewCardsStudied = 7)
+
+                s.recalculateGoals(availableNewGoal = 0, availableReviewGoal = 0)
+
+                // min(5, 7+0) = 5, studied 초과분이 goal을 끌어올리지 않는다
+                s.newCardsGoal shouldBe 5
+                s.reviewCardsGoal shouldBe 5
+            }
+        }
+
+        describe("completeIfGoalAchieved") {
+            it("new와 review 둘 다 studied가 goal 이상이면 세션을 완료 상태로 전환한다") {
+                val now = Instant.now()
+                val s = createSession(newCardsGoal = 2, newCardsStudied = 2, reviewCardsGoal = 3, reviewCardsStudied = 3)
+
+                s.completeIfGoalAchieved(now)
+
+                s.status shouldBe StudySessionStatus.COMPLETED
+                s.endedAt shouldBe now
+            }
+
+            it("review의 studied가 goal 미만이면 세션을 활성 상태를 유지한다") {
+                val now = Instant.now()
+                // review가 미달
+                val s = createSession(newCardsGoal = 2, newCardsStudied = 2, reviewCardsGoal = 3, reviewCardsStudied = 1)
+
+                s.completeIfGoalAchieved(now)
+
+                s.status shouldBe StudySessionStatus.ACTIVE
+                s.endedAt.shouldBeNull()
+            }
+
+            it("new의 studied가 goal 미만이면 세션을 활성 상태를 유지한다") {
+                val now = Instant.now()
+                // new가 미달
+                val s = createSession(newCardsGoal = 2, newCardsStudied = 1, reviewCardsGoal = 3, reviewCardsStudied = 3)
+
+                s.completeIfGoalAchieved(now)
+
+                s.status shouldBe StudySessionStatus.ACTIVE
+                s.endedAt.shouldBeNull()
+            }
+
+            it("goal이 0,0이면 세션을 완료 상태로 전환한다.") {
+                val now = Instant.now()
+                val s = createSession(newCardsGoal = 0, newCardsStudied = 0, reviewCardsGoal = 0, reviewCardsStudied = 0)
+
+                s.completeIfGoalAchieved(now)
+
+                s.status shouldBe StudySessionStatus.COMPLETED
             }
         }
     })


### PR DESCRIPTION
## 📌 Related Issue
Closes #49 

## 📝 Changes
### 카드 삭제 이벤트를 수신해 LearningState를 정리하고, 활성 상태의 일일학습 세션 목표를 조정
- CardLearningState Entity가 SoftdeletableEntity를 상속하도록 변경
  - study 모듈 flyway 마이그레이션 파일 v6 추가
- CardLearningStateEventListener
  - `interval/event` 하위로 이동
  - 삭제 이벤트 리스너 추가
- CardsDeletedEvent에 `삭제된 card id`, `deletedAt` 프로퍼티 추가

### 학습 세션 목표 조정
- 카드 삭제 시 활성화된 일일 학습 세션의 목표 수치를 조정
- 카드 평가 시 세션 완료 조건을 entity 내부로 이동
- 학습을 완료하지 않은 상태에서 모든 카드가 제거되어 학습 진행이 불가능할 때 debug 로그 추가

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
- local profile에서 Hibernate SQL logging level을 debug로 수정
- 어떻게 조절했는지는 notion에 문서로 남겨두었습니다! [(링크)](https://app.notion.com/p/given-dragon/379870f222b980299621f7d806591f08)