### PR TITLE
[Feat] Deck 목록 조회 추가 

### DIFF
--- a/src/main/kotlin/com/whatever/caro/bff/ModuleMetadata.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/ModuleMetadata.kt
@@ -6,6 +6,6 @@ import org.springframework.modulith.PackageInfo
 @PackageInfo
 @ApplicationModule(
     displayName = "BackendForFrontend",
-    allowedDependencies = ["common", "study", "card :: card", "auth"],
+    allowedDependencies = ["common", "study", "card :: card", "card :: deck", "auth"],
 )
 class ModuleMetadata

--- a/src/main/kotlin/com/whatever/caro/bff/internal/CardLearningStateBadge.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/CardLearningStateBadge.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.bff.internal
+
+enum class CardLearningStateBadge {
+    NEW,
+    REVIEW,
+    HARD,
+}

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
@@ -1,0 +1,70 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.card.api.card.CardApi
+import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckPresetApi
+import com.whatever.caro.study.CardLearningStateDto
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudyApi
+import org.springframework.stereotype.Service
+
+@Service
+class DeckBFFService(
+    private val cardApi: CardApi,
+    private val studyApi: StudyApi,
+    private val deckPresetApi: DeckPresetApi,
+) {
+    fun getCardsWithLearningState(
+        userId: Long,
+        deckId: Long,
+    ): List<DeckCardItem> {
+        val cards = cardApi.getCardContentsByDeck(
+            userId = userId,
+            deckId = deckId,
+        ).takeIf { it.isNotEmpty() } ?: return emptyList()
+
+        val learningStateByCardId = studyApi.getLearningStates(
+            userId = userId,
+            cardIds = cards.map { it.cardId },
+        )
+        val deckPreset = deckPresetApi.getLatestDeckPresetByUser(deckId, userId)
+
+        return cards.map { card ->
+            toDeckCardItem(
+                card = card,
+                state = learningStateByCardId[card.cardId],
+                hardBadgeThreshold = deckPreset.hardBadgeThreshold,
+            )
+        }
+    }
+}
+
+private fun toDeckCardItem(
+    card: CardContentDto,
+    state: CardLearningStateDto?,
+    hardBadgeThreshold: Int,
+): DeckCardItem =
+    DeckCardItem(
+        cardId = card.cardId,
+        fields = card.fields,
+
+        // state가 생성되지 않았을 경우 NEW 카드로 반환
+        badge = state?.toBadge(hardBadgeThreshold) ?: CardLearningStateBadge.NEW,
+        reviewCount = state?.totalReviews ?: 0,
+    )
+
+private fun CardLearningStateDto.toBadge(
+    hardBadgeThreshold: Int,
+): CardLearningStateBadge {
+    // SUSPENDED를 먼저 차단
+    val baseBadge = when (status) {
+        CardLearningStatus.NEW -> CardLearningStateBadge.NEW
+        CardLearningStatus.REVIEW -> CardLearningStateBadge.REVIEW
+        CardLearningStatus.SUSPENDED -> error("SUSPENDED status is not supported")
+    }
+
+    if (consecutiveAgainCount >= hardBadgeThreshold) {
+        return CardLearningStateBadge.HARD
+    }
+    return baseBadge
+}

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
@@ -2,17 +2,23 @@ package com.whatever.caro.bff.internal
 
 import com.whatever.caro.card.api.card.CardApi
 import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckApi
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.study.CardLearningStateDto
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.StudyApi
+import com.whatever.caro.study.TodayStudySessionState
+import com.whatever.caro.study.TodaySummaryState
 import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.ZoneId
 
 @Service
 class DeckBFFService(
     private val cardApi: CardApi,
     private val studyApi: StudyApi,
     private val deckPresetApi: DeckPresetApi,
+    private val deckApi: DeckApi,
 ) {
     fun getCardsWithLearningState(
         userId: Long,
@@ -37,7 +43,63 @@ class DeckBFFService(
             )
         }
     }
+
+    fun getDecksWithDailyStudySession(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+    ): List<DeckListItem> {
+        val decks = deckApi.getDecks(userId).takeIf { it.isNotEmpty() } ?: return emptyList()
+
+        val todaySummaryByDeckId = studyApi.getTodaySummaries(
+            now = now,
+            timezone = timezone,
+            userId = userId,
+            deckIds = decks.map { it.id }.toSet(),
+        )
+
+        return decks.map { deck ->
+            DeckListItem(
+                deckId = deck.id,
+                name = deck.name,
+                description = deck.description,
+                cardCount = deck.cardCount,
+                progress = todaySummaryByDeckId.getValue(deck.id).toDeckProgress(),
+            )
+        }
+    }
 }
+
+private fun TodayStudySessionState.toDeckProgress(): StudySessionProgress =
+    when (this) {
+        is TodayStudySessionState.InProgress -> StudySessionProgress(
+            state = TodaySummaryState.IN_PROGRESS,
+            sessionId = session.sessionId,
+            studiedCardCount = session.newCardsStudied + session.reviewCardsStudied,
+            totalCardCount = session.estimatedTotal,
+        )
+
+        is TodayStudySessionState.Completed -> StudySessionProgress(
+            state = TodaySummaryState.COMPLETED,
+            sessionId = session.sessionId,
+            studiedCardCount = session.newCardsStudied + session.reviewCardsStudied,
+            totalCardCount = session.estimatedTotal,
+        )
+
+        is TodayStudySessionState.NotStarted -> StudySessionProgress(
+            state = TodaySummaryState.NOT_STARTED,
+            sessionId = null,
+            studiedCardCount = 0,
+            totalCardCount = pool.newCount + pool.reviewCount,
+        )
+
+        is TodayStudySessionState.RestDay -> StudySessionProgress(
+            state = TodaySummaryState.REST_DAY,
+            sessionId = null,
+            studiedCardCount = 0,
+            totalCardCount = 0,
+        )
+    }
 
 private fun toDeckCardItem(
     card: CardContentDto,

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckCardItem.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckCardItem.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.bff.internal
+
+data class DeckCardItem(
+    val cardId: Long,
+    val fields: Map<String, String>,
+    val badge: CardLearningStateBadge,
+    val reviewCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckListItem.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckListItem.kt
@@ -1,0 +1,18 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.study.TodaySummaryState
+
+data class DeckListItem(
+    val deckId: Long,
+    val name: String,
+    val description: String,
+    val cardCount: Int,
+    val progress: StudySessionProgress,
+)
+
+data class StudySessionProgress(
+    val state: TodaySummaryState,
+    val sessionId: Long?,
+    val studiedCardCount: Int,
+    val totalCardCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -1,11 +1,49 @@
 package com.whatever.caro.bff.internal.web
 
-import com.whatever.caro.study.StudyApi
+import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.bff.internal.DeckBFFService
+import com.whatever.caro.bff.internal.DeckCardItem
+import com.whatever.caro.bff.internal.web.response.DeckCardResponse
+import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RestController("/v1/decks")
+@Tag(name = "Deck Card Information", description = "Deck card information")
+@RestController
 class DeckBFFController(
-    private val studyApi: StudyApi,
+    private val deckBFFService: DeckBFFService,
 ) {
-    // TODO card 모듈 merge 후 추가구현
+
+    @Operation(
+        summary = "덱에 있는 카드 조회",
+        description = """
+        덱에 있는 모든 카드를 조회한다.
+        각 카드별로 학습 상태를 기반으로 NEW/REVIEW/HARD badge, 복습 수가 함께 제공된다.
+        """,
+    )
+    @GetMapping("/v2/decks/{deckId}/cards")
+    fun getCardsByDeck(
+        @Parameter(description = "덱 ID", required = true) @PathVariable deckId: Long,
+    ): ResponseEntity<ApiResponse<List<DeckCardResponse>>> {
+        val userId = SecurityUtil.currentUser().userId
+        val cards = deckBFFService.getCardsWithLearningState(
+            userId = userId,
+            deckId = deckId,
+        )
+        return ResponseEntity.ok(ApiResponse.ok(cards.map { it.toResponse() }))
+    }
 }
+
+private fun DeckCardItem.toResponse(): DeckCardResponse =
+    DeckCardResponse(
+        cardId = cardId,
+        fields = fields,
+        badge = badge,
+        reviewCount = reviewCount,
+    )

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -3,7 +3,11 @@ package com.whatever.caro.bff.internal.web
 import com.whatever.caro.auth.SecurityUtil
 import com.whatever.caro.bff.internal.DeckBFFService
 import com.whatever.caro.bff.internal.DeckCardItem
+import com.whatever.caro.bff.internal.DeckListItem
+import com.whatever.caro.bff.internal.StudySessionProgress
 import com.whatever.caro.bff.internal.web.response.DeckCardResponse
+import com.whatever.caro.bff.internal.web.response.DeckListResponse
+import com.whatever.caro.bff.internal.web.response.StudySessionProgressResponse
 import com.whatever.caro.common.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -11,12 +15,16 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 @Tag(name = "Deck Card Information", description = "Deck card information")
 @RestController
 class DeckBFFController(
+    private val clock: Clock,
     private val deckBFFService: DeckBFFService,
 ) {
 
@@ -38,6 +46,31 @@ class DeckBFFController(
         )
         return ResponseEntity.ok(ApiResponse.ok(cards.map { it.toResponse() }))
     }
+
+    @Operation(
+        summary = "홈 화면 덱 목록 조회",
+        description = """
+        홈 화면에 표시될 덱 목록을 조회한다.
+        각 덱마다 오늘의 일일학습 진행 정보(progress)가 포함된다.
+
+        totalCardCount는 모든 상태에서 "오늘 학습 목표 장 수"를 의미한다.
+        (NOT_STARTED는 오늘 학습 목표의 합, REST_DAY는 0)
+        """,
+    )
+    @GetMapping("/v1/decks")
+    fun getDecks(
+        @RequestHeader("Client-Timezone", required = true) timezone: ZoneId,
+    ): ResponseEntity<ApiResponse<List<DeckListResponse>>> {
+        val now = Instant.now(clock)
+        val userId = SecurityUtil.currentUser().userId
+
+        val decks = deckBFFService.getDecksWithDailyStudySession(
+            now = now,
+            timezone = timezone,
+            userId = userId,
+        )
+        return ResponseEntity.ok(ApiResponse.ok(decks.map { it.toResponse() }))
+    }
 }
 
 private fun DeckCardItem.toResponse(): DeckCardResponse =
@@ -46,4 +79,21 @@ private fun DeckCardItem.toResponse(): DeckCardResponse =
         fields = fields,
         badge = badge,
         reviewCount = reviewCount,
+    )
+
+private fun DeckListItem.toResponse(): DeckListResponse =
+    DeckListResponse(
+        deckId = deckId,
+        name = name,
+        description = description,
+        cardCount = cardCount,
+        progress = progress.toResponse(),
+    )
+
+private fun StudySessionProgress.toResponse(): StudySessionProgressResponse =
+    StudySessionProgressResponse(
+        state = state,
+        sessionId = sessionId,
+        studiedCardCount = studiedCardCount,
+        totalCardCount = totalCardCount,
     )

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckCardResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckCardResponse.kt
@@ -1,0 +1,10 @@
+package com.whatever.caro.bff.internal.web.response
+
+import com.whatever.caro.bff.internal.CardLearningStateBadge
+
+data class DeckCardResponse(
+    val cardId: Long,
+    val fields: Map<String, String>,
+    val badge: CardLearningStateBadge,
+    val reviewCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckListResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/response/DeckListResponse.kt
@@ -1,0 +1,18 @@
+package com.whatever.caro.bff.internal.web.response
+
+import com.whatever.caro.study.TodaySummaryState
+
+data class DeckListResponse(
+    val deckId: Long,
+    val name: String,
+    val description: String,
+    val cardCount: Int,
+    val progress: StudySessionProgressResponse,
+)
+
+data class StudySessionProgressResponse(
+    val state: TodaySummaryState,
+    val sessionId: Long?,
+    val studiedCardCount: Int,
+    val totalCardCount: Int,
+)

--- a/src/main/kotlin/com/whatever/caro/card/api/card/CardApi.kt
+++ b/src/main/kotlin/com/whatever/caro/card/api/card/CardApi.kt
@@ -5,4 +5,9 @@ interface CardApi {
         userId: Long,
         cardIds: Collection<Long>,
     ): Map<Long, CardContentDto>
+
+    fun getCardContentsByDeck(
+        userId: Long,
+        deckId: Long,
+    ): List<CardContentDto>
 }

--- a/src/main/kotlin/com/whatever/caro/card/api/deck/DeckPresetApi.kt
+++ b/src/main/kotlin/com/whatever/caro/card/api/deck/DeckPresetApi.kt
@@ -11,6 +11,11 @@ interface DeckPresetApi {
     fun getDeckPresetById(
         deckPresetIdSnapshot: Long,
     ): DeckPresetDto
+
+    fun getLatestDeckPresetsByDeckId(
+        userId: Long,
+        deckIds: Collection<Long>,
+    ): Map<Long, DeckPresetDto>
 }
 
 data class DeckPresetDto(

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -44,6 +44,7 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
+    @Deprecated(message = "v2 메서드로 변경 필요")
     @GetMapping("/v1/decks/{deckId}/cards")
     fun getCardsByDeck(
         @Parameter(description = "덱 ID", required = true)

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -165,10 +165,12 @@ class CardService(
         deckId: Long,
     ): List<CardContentDto> {
         val cardResponseDtos = getCardsByDeck(userId, deckId)
-        return cardResponseDtos.map { CardContentDto(
-            cardId = it.cardId,
-            fields = it.fields,
-        ) }
+        return cardResponseDtos.map {
+            CardContentDto(
+                cardId = it.cardId,
+                fields = it.fields,
+            )
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -159,6 +159,18 @@ class CardService(
             }
     }
 
+    @Transactional(readOnly = true)
+    override fun getCardContentsByDeck(
+        userId: Long,
+        deckId: Long,
+    ): List<CardContentDto> {
+        val cardResponseDtos = getCardsByDeck(userId, deckId)
+        return cardResponseDtos.map { CardContentDto(
+            cardId = it.cardId,
+            fields = it.fields,
+        ) }
+    }
+
     @Transactional
     fun updateCard(
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
@@ -5,6 +5,20 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface DeckRepository : JpaRepository<Deck, Long> {
+    @Query(
+        """
+        select d from Deck d
+            join fetch d.deckPreset
+        where d.id in :deckIds
+            and d.userId = :userId
+            and d.deletedAt is null
+        """,
+    )
+    fun findAllByIdInWithPreset(
+        userId: Long,
+        deckIds: Collection<Long>,
+    ): List<Deck>
+
     fun findByUserIdAndDeletedAtIsNull(
         userId: Long,
     ): List<Deck>

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetService.kt
@@ -19,6 +19,18 @@ class DeckPresetService(
 ) : DeckPresetApi {
 
     @Transactional(readOnly = true)
+    override fun getLatestDeckPresetsByDeckId(
+        userId: Long,
+        deckIds: Collection<Long>,
+    ): Map<Long, DeckPresetDto> =
+        deckRepository.findAllByIdInWithPreset(
+            userId = userId,
+            deckIds = deckIds,
+        ).mapNotNull { deck ->
+            deck.deckPreset?.let { deck.id to it.toDto() }
+        }.toMap()
+
+    @Transactional(readOnly = true)
     override fun getLatestDeckPresetByUser(
         deckId: Long,
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -27,4 +27,11 @@ interface StudyApi {
         sessionId: Long,
         now: Instant,
     ): List<CardLearningStateDto>
+
+    fun getTodaySummaries(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+        deckIds: Set<Long>,
+    ): Map<Long, TodayStudySessionState>
 }

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -6,18 +6,6 @@ import java.time.ZoneId
 // TODO StudySessionApi로 분리
 interface StudyApi {
     /**
-     * 오늘 학습 세션에 대한 정보를 반환한다.
-     *
-     * 시각은 caller(요청 진입 시점)가 결정한 단일 `now`를 전달받아 도메인 호출 간 일관성을 보장한다.
-     */
-    fun getTodaySummary(
-        now: Instant,
-        timezone: ZoneId,
-        userId: Long,
-        deckId: Long,
-    ): TodayStudySessionState
-
-    /**
      * 카드별 LearningStates를 cardId 기준 맵으로 반환한다.
      */
     fun getLearningStates(

--- a/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyApi.kt
@@ -18,8 +18,7 @@ interface StudyApi {
     ): TodayStudySessionState
 
     /**
-     * 카드별 학습 상태를 cardId 기준 맵으로 반환한다.
-     * 평가 이력이 없는 카드는 맵에 포함되지 않으므로, 호출 측에서 부재를 처리한다.
+     * 카드별 LearningStates를 cardId 기준 맵으로 반환한다.
      */
     fun getLearningStates(
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/study/StudyTargetPoolCalculator.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StudyTargetPoolCalculator.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.study
 
+import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -42,6 +43,36 @@ class StudyTargetPoolCalculator(
             newCount = newPool,
             reviewCount = reviewPool,
         )
+    }
+
+    @Transactional(readOnly = true)
+    fun getTodayPools(
+        now: Instant,
+        timezone: ZoneId,
+        presetByDeckId: Map<Long, DeckPresetDto>,
+        dayCutoffHour: Int,
+    ): Map<Long, StudyTargetPoolCount> {
+        if (presetByDeckId.isEmpty()) {
+            return emptyMap()
+        }
+
+        val nextSessionStart = getNextSessionStart(now, timezone, dayCutoffHour)
+
+        val deckIds = presetByDeckId.keys
+        val newCardCountByDeckId = cardLearningStateRepository.countNewCardsByDeckIds(
+            deckIds = deckIds,
+        ).associate { it.deckId to it.count.toInt() }
+        val reviewCardCountByDeckId = cardLearningStateRepository.countReviewCardsByDeckIds(
+            deckIds = deckIds,
+            nextSessionStart = nextSessionStart,
+        ).associate { it.deckId to it.count.toInt() }
+
+        return presetByDeckId.mapValues { (deckId, preset) ->
+            StudyTargetPoolCount(
+                newCount = min(preset.newPerDay, newCardCountByDeckId[deckId] ?: 0),
+                reviewCount = min(preset.reviewPerDay, reviewCardCountByDeckId[deckId] ?: 0),
+            )
+        }
     }
 
     /**

--- a/src/main/kotlin/com/whatever/caro/study/internal/DeckCardCount.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/DeckCardCount.kt
@@ -1,0 +1,6 @@
+package com.whatever.caro.study.internal
+
+data class DeckCardCount(
+    val deckId: Long,
+    val count: Long,
+)

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -227,6 +227,62 @@ class StudyService(
         val learningStates = cardLearningStateRepository.findAllByUserIdAndCardIdInAndDeletedAtIsNull(userId, cardIds)
         return learningStates.associate { it.cardId to it.toDto() }
     }
+
+    @Transactional(readOnly = true)
+    override fun getTodaySummaries(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+        deckIds: Set<Long>,
+    ): Map<Long, TodayStudySessionState> {
+        if (deckIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        val todaySessionByDeckId = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+            userId,
+            deckIds,
+        ).filter { session ->
+            when (session.status) {
+                StudySessionStatus.ACTIVE, StudySessionStatus.COMPLETED -> session.isTodaySession(now)
+                StudySessionStatus.STOPPED -> false
+            }
+        }.associateBy { it.deckId }
+
+        val noSessionDeckIds = deckIds - todaySessionByDeckId.keys
+        val presetByDeckId = if (noSessionDeckIds.isNotEmpty()) {
+            deckPresetApi.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = noSessionDeckIds,
+            )
+        } else {
+            emptyMap()
+        }
+        val todayPoolByDeckId = studyTargetPoolCalculator.getTodayPools(
+            now = now,
+            timezone = timezone,
+            presetByDeckId = presetByDeckId,
+            dayCutoffHour = 0,
+        )
+
+        return deckIds.associateWith { deckId ->
+            todaySessionByDeckId[deckId]?.let { session ->
+                if (session.status == StudySessionStatus.ACTIVE) {
+                    TodayStudySessionState.InProgress(session.toDto())
+                } else {
+                    TodayStudySessionState.Completed(session.toDto())
+                }
+            } ?: run {
+                val preset = checkNotNull(presetByDeckId[deckId]) { "deck에 연결된 preset이 없습니다. deckId=$deckId" }
+                val pool = todayPoolByDeckId.getValue(deckId)
+                if (pool.newCount == 0 && pool.reviewCount == 0) {
+                    TodayStudySessionState.RestDay
+                } else {
+                    TodayStudySessionState.NotStarted(pool, preset.id)
+                }
+            }
+        }
+    }
 }
 
 private fun CardLearningState.toDto(): CardLearningStateDto =

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -119,7 +119,7 @@ class StudyService(
     }
 
     @Transactional(readOnly = true)
-    override fun getTodaySummary(
+    fun getTodaySummary(
         now: Instant,
         timezone: ZoneId,
         userId: Long,

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.study.internal.cardlearningstate
 
+import com.whatever.caro.study.internal.DeckCardCount
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -98,4 +99,32 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
         deckId: Long,
         sessionStart: Instant,
     ): Int
+
+    @Query(
+        """
+        select new com.whatever.caro.study.internal.DeckCardCount(cls.deckId, count(cls)) from CardLearningState cls
+        where cls.deckId in :deckIds
+            and cls.status = CardLearningStatus.NEW
+            and cls.deletedAt is null
+        group by cls.deckId
+        """,
+    )
+    fun countNewCardsByDeckIds(
+        deckIds: Collection<Long>,
+    ): List<DeckCardCount>
+
+    @Query(
+        """
+        select new com.whatever.caro.study.internal.DeckCardCount(cls.deckId, count(cls)) from CardLearningState cls
+        where cls.deckId in :deckIds
+            and cls.status = CardLearningStatus.REVIEW
+            and cls.deletedAt is null
+            and cls.nextReviewAt < :nextSessionStart
+        group by cls.deckId
+        """,
+    )
+    fun countReviewCardsByDeckIds(
+        deckIds: Collection<Long>,
+        nextSessionStart: Instant,
+    ): List<DeckCardCount>
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepository.kt
@@ -37,4 +37,23 @@ interface StudySessionRepository : JpaRepository<StudySession, Long> {
         id: Long,
         userId: Long,
     ): StudySession?
+
+    @Query(
+        """
+        select ss from StudySession ss
+        where ss.userId = :userId
+            and ss.deckId in :deckIds
+            and not exists (
+                select 1 from StudySession ss2
+                where ss2.userId = :userId
+                    and ss2.deckId = ss.deckId
+                    and (ss2.startedAt > ss.startedAt
+                            or (ss2.startedAt = ss.startedAt and ss2.id > ss.id))
+            )
+        """,
+    )
+    fun findLatestByUserIdAndDeckIdIn(
+        userId: Long,
+        deckIds: Set<Long>,
+    ): List<StudySession>
 }

--- a/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
@@ -1,0 +1,200 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.card.api.card.CardApi
+import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckPresetApi
+import com.whatever.caro.card.api.deck.DeckPresetDto
+import com.whatever.caro.study.CardLearningStateDto
+import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.StudyApi
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.engine.test.logging.error
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.math.BigDecimal
+
+class DeckBFFServiceUnitTest :
+    DescribeSpec({
+
+        val cardApi = mockk<CardApi>()
+        val studyApi = mockk<StudyApi>()
+        val deckPresetApi = mockk<DeckPresetApi>()
+        val service = DeckBFFService(cardApi = cardApi, studyApi = studyApi, deckPresetApi = deckPresetApi)
+
+        val userId = 1L
+        val deckId = 7L
+
+        fun createCardContent(
+            cardId: Long,
+        ): CardContentDto =
+            CardContentDto(
+                cardId = cardId,
+                fields = mapOf("front" to "Q$cardId", "back" to "A$cardId"),
+            )
+
+        fun createCls(
+            cardId: Long,
+            status: CardLearningStatus = CardLearningStatus.NEW,
+            totalReviews: Int = 0,
+            consecutiveAgainCount: Int = 0,
+        ): CardLearningStateDto =
+            CardLearningStateDto(
+                cardId = cardId,
+                status = status,
+                totalReviews = totalReviews,
+                consecutiveAgainCount = consecutiveAgainCount,
+            )
+
+        fun createPreset(
+            hardBadgeThreshold: Int = 3,
+        ): DeckPresetDto =
+            DeckPresetDto(
+                id = 1L,
+                userId = userId,
+                name = "기본 프리셋",
+                newPerDay = 10,
+                newFairInterval = 1,
+                newEasyInterval = 4,
+                newInitialEaseFactor = BigDecimal("2.5"),
+                reviewPerDay = 100,
+                reviewMaxInterval = 365,
+                lapseIntervalMultiplier = BigDecimal("0.5"),
+                lapseMinInterval = 1,
+                leechThreshold = 8,
+                hardBadgeThreshold = hardBadgeThreshold,
+            )
+
+        fun stubDeckInformation(
+            cards: List<CardContentDto>,
+            states: List<CardLearningStateDto>,
+            hardBadgeThreshold: Int = 3,
+        ) {
+            every {
+                cardApi.getCardContentsByDeck(userId = userId, deckId = deckId)
+            } returns cards
+
+            every {
+                studyApi.getLearningStates(userId = userId, cardIds = cards.map { it.cardId })
+            } returns states.associateBy { it.cardId }
+
+            every {
+                deckPresetApi.getLatestDeckPresetByUser(deckId = deckId, userId = userId)
+            } returns createPreset(hardBadgeThreshold = hardBadgeThreshold)
+        }
+
+        afterTest {
+            clearMocks(cardApi, studyApi, deckPresetApi)
+        }
+
+        describe("getCardsWithLearningState") {
+
+            it("덱 카드들을 learningState/preset과 조합해 순서를 유지하며 DeckCardItem 리스트로 매핑한다") {
+                val cards = (1L..3L).map { i -> createCardContent(i) }
+                val states = listOf(
+                    createCls(cardId = 1L, status = CardLearningStatus.NEW, totalReviews = 0, consecutiveAgainCount = 0),
+                    createCls(cardId = 2L, status = CardLearningStatus.REVIEW, totalReviews = 3, consecutiveAgainCount = 1),
+                    createCls(cardId = 3L, status = CardLearningStatus.REVIEW, totalReviews = 10, consecutiveAgainCount = 2),
+                )
+                stubDeckInformation(cards = cards, states = states, hardBadgeThreshold = 8)
+
+                val result = service.getCardsWithLearningState(userId, deckId)
+
+                result.map { it.cardId } shouldContainExactly cards.map { it.cardId }
+                repeat(3) { i ->
+                    when (states[i].status) {
+                        CardLearningStatus.NEW -> result[i].badge shouldBe CardLearningStateBadge.NEW
+                        CardLearningStatus.REVIEW -> result[i].badge shouldBe CardLearningStateBadge.REVIEW
+                        CardLearningStatus.SUSPENDED -> error("SUSPENDED status is not supported")
+                    }
+                    result[i].reviewCount shouldBe states[i].totalReviews
+                }
+            }
+
+            context("early return 케이스") {
+                it("덱에 카드가 없으면 빈 리스트를 반환하고 study/preset API를 호출하지 않는다") {
+                    every { cardApi.getCardContentsByDeck(userId = userId, deckId = deckId) } returns emptyList()
+
+                    val result = service.getCardsWithLearningState(userId, deckId)
+
+                    result.shouldBeEmpty()
+                    verify(exactly = 0) { studyApi.getLearningStates(any(), any()) }
+                    verify(exactly = 0) { deckPresetApi.getLatestDeckPresetByUser(any(), any()) }
+                }
+            }
+
+            it("learningState가 없는 카드는 badge=NEW, reviewCount=0으로 반환한다") {
+                val cards = listOf(createCardContent(1L), createCardContent(2L))
+
+                // 2L 카드 누락
+                val states = listOf(createCls(1L, status = CardLearningStatus.REVIEW, totalReviews = 4))
+                stubDeckInformation(
+                    cards = cards,
+                    states = states,
+                )
+
+                val result = service.getCardsWithLearningState(userId, deckId)
+
+                result[0].badge shouldBe CardLearningStateBadge.REVIEW
+                result[0].reviewCount shouldBe states.first().totalReviews
+                result[1].badge shouldBe CardLearningStateBadge.NEW
+                result[1].reviewCount shouldBe 0
+            }
+
+            context("badge 매핑 확인") {
+                data class BadgeCase(
+                    val againCount: Int,
+                    val threshold: Int,
+                    val status: CardLearningStatus,
+                    val expected: CardLearningStateBadge,
+                    val reason: String,
+                )
+
+                withData(
+                    nameFn = {
+                        "againCount=${it.againCount}, threshold=${it.threshold}, " +
+                            "status=${it.status} -> ${it.expected} (${it.reason})"
+                    },
+                    BadgeCase(2, 3, CardLearningStatus.NEW, CardLearningStateBadge.NEW, "미만이면 baseBadge 유지"),
+                    BadgeCase(2, 3, CardLearningStatus.REVIEW, CardLearningStateBadge.REVIEW, "미만이면 baseBadge 유지"),
+                    BadgeCase(3, 3, CardLearningStatus.REVIEW, CardLearningStateBadge.HARD, "threshold==againCount"),
+                    BadgeCase(4, 3, CardLearningStatus.REVIEW, CardLearningStateBadge.HARD, "threshold 초과"),
+                    BadgeCase(3, 3, CardLearningStatus.NEW, CardLearningStateBadge.HARD, "NEW여도 HARD가 우선 반영"),
+                    BadgeCase(0, 0, CardLearningStatus.NEW, CardLearningStateBadge.HARD, "threshold=0이면 0회도 HARD"),
+                ) { (againCount, threshold, status, expected, _) ->
+                    val cardId = 1L
+                    val cards = listOf(createCardContent(cardId))
+                    val states = listOf(createCls(cardId, status = status, consecutiveAgainCount = againCount))
+                    stubDeckInformation(
+                        cards = cards,
+                        states = states,
+                        hardBadgeThreshold = threshold,
+                    )
+
+                    val result = service.getCardsWithLearningState(userId, deckId)
+
+                    result.first().badge shouldBe expected
+                }
+
+                it("SUSPENDED status는 지원하지 않으므로 IllegalStateException을 던진다") {
+                    val cardId = 1L
+                    val cards = listOf(createCardContent(cardId))
+                    val states = listOf(createCls(1L, status = CardLearningStatus.SUSPENDED))
+                    stubDeckInformation(
+                        cards = cards,
+                        states = states,
+                    )
+
+                    shouldThrow<IllegalStateException> {
+                        service.getCardsWithLearningState(userId, deckId)
+                    }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
@@ -2,6 +2,7 @@ package com.whatever.caro.bff.internal
 
 import com.whatever.caro.card.api.card.CardApi
 import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.card.api.deck.DeckApi
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.CardLearningStateDto
@@ -10,7 +11,6 @@ import com.whatever.caro.study.StudyApi
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
-import io.kotest.engine.test.logging.error
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -26,10 +26,11 @@ class DeckBFFServiceUnitTest :
         val cardApi = mockk<CardApi>()
         val studyApi = mockk<StudyApi>()
         val deckPresetApi = mockk<DeckPresetApi>()
-        val service = DeckBFFService(cardApi = cardApi, studyApi = studyApi, deckPresetApi = deckPresetApi)
+        val deckApi = mockk<DeckApi>()
+        val service = DeckBFFService(cardApi = cardApi, studyApi = studyApi, deckPresetApi = deckPresetApi, deckApi = deckApi)
 
         val userId = 1L
-        val deckId = 7L
+        val deckId = 1L
 
         fun createCardContent(
             cardId: Long,

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetServiceTest.kt
@@ -10,6 +10,7 @@ import com.whatever.caro.card.internal.deck.exception.DeckNotFoundException
 import com.whatever.caro.card.internal.deck.exception.DeckPresetNotFoundException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
@@ -86,6 +87,96 @@ class DeckPresetServiceTest(
             shouldThrow<DeckPresetNotFoundException> {
                 deckPresetService.getLatestDeckPresetByUser(deck.id, userId)
             }
+        }
+    }
+
+    describe("getLatestDeckPresetsByDeckId") {
+        it("덱별로 연결된 프리셋이 deckId 기준 맵으로 반환된다") {
+            val userId = 1L
+            val preset1 = savePreset(userId = userId, name = "프리셋1")
+            val preset2 = savePreset(userId = userId, name = "프리셋2")
+            val deck1 = saveDeck(userId = userId, preset = preset1)
+            val deck2 = saveDeck(userId = userId, preset = preset2)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deck1.id, deck2.id),
+            )
+
+            result.keys shouldBe setOf(deck1.id, deck2.id)
+            result[deck1.id]?.id shouldBe preset1.id
+            result[deck2.id]?.id shouldBe preset2.id
+        }
+
+        it("여러 덱이 같은 프리셋을 공유하면 모든 deckId 키가 같은 프리셋을 가리킨다") {
+            val userId = 1L
+            val sharedPreset = savePreset(userId = userId, name = "공유 프리셋")
+            val deck1 = saveDeck(userId = userId, preset = sharedPreset)
+            val deck2 = saveDeck(userId = userId, preset = sharedPreset)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deck1.id, deck2.id),
+            )
+
+            result[deck1.id]?.id shouldBe sharedPreset.id
+            result[deck2.id]?.id shouldBe sharedPreset.id
+        }
+
+        it("프리셋이 연결되지 않은 덱은 결과 키에서 제외된다") {
+            val userId = 1L
+            val preset = savePreset(userId = userId)
+            val deckWithPreset = saveDeck(userId = userId, preset = preset)
+            val deckWithoutPreset = saveDeck(userId = userId, preset = null)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deckWithPreset.id, deckWithoutPreset.id),
+            )
+
+            result.keys shouldBe setOf(deckWithPreset.id)
+        }
+
+        it("다른 유저의 덱은 결과 키에서 제외된다") {
+            val myPreset = savePreset(userId = 1L)
+            val otherPreset = savePreset(userId = 2L)
+            val myDeck = saveDeck(userId = 1L, preset = myPreset)
+            val otherDeck = saveDeck(userId = 2L, preset = otherPreset)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = 1L,
+                deckIds = setOf(myDeck.id, otherDeck.id),
+            )
+
+            result.keys shouldBe setOf(myDeck.id)
+        }
+
+        it("soft delete된 덱은 결과 키에서 제외된다") {
+            val userId = 1L
+            val preset = savePreset(userId = userId)
+            val deck = saveDeck(userId = userId, preset = preset)
+            deck.softDelete(deletedAt = Instant.now())
+            deckRepository.save(deck)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = setOf(deck.id),
+            )
+
+            result.shouldBeEmpty()
+        }
+
+        it("빈 deckIds면 빈 맵을 반환한다") {
+            val userId = 1L
+            val preset = savePreset(userId = userId)
+            saveDeck(userId = userId, preset = preset)
+
+            val result = deckPresetService.getLatestDeckPresetsByDeckId(
+                userId = userId,
+                deckIds = emptySet(),
+            )
+
+            result.shouldBeEmpty()
         }
     }
 

--- a/src/test/kotlin/com/whatever/caro/study/StudyTargetPoolCalculatorTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/StudyTargetPoolCalculatorTest.kt
@@ -1,8 +1,11 @@
 package com.whatever.caro.study
 
+import com.whatever.caro.study.internal.DeckCardCount
+import com.whatever.caro.study.internal.Sm2ParamsFixture
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -134,6 +137,142 @@ class StudyTargetPoolCalculatorTest :
                     repo.countTodayReviewCards(
                         userId = 1L,
                         deckId = 1L,
+                        nextSessionStart = LocalDateTime.parse(case.expectedNextSessionStart).atZone(case.timezone).toInstant(),
+                    )
+                }
+            }
+        }
+
+        describe("getTodayPools") {
+            it("덱별 카드 수가 perDay보다 많으면 perDay까지만, 적으면 카드 수 그대로 반환된다") {
+                val (calc, repo) = createCalculator()
+                val presetByDeckId = mapOf(
+                    1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 2, reviewPerDay = 1),
+                    2L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                )
+                every { repo.countNewCardsByDeckIds(any()) } returns
+                    listOf(DeckCardCount(1L, 5), DeckCardCount(2L, 4))
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns
+                    listOf(DeckCardCount(1L, 3), DeckCardCount(2L, 2))
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = presetByDeckId,
+                    dayCutoffHour = 0,
+                )
+
+                result[1L] shouldBe StudyTargetPoolCount(newCount = 2, reviewCount = 1)
+                result[2L] shouldBe StudyTargetPoolCount(newCount = 4, reviewCount = 2)
+            }
+
+            it("count 결과에 행이 없는 덱은 pool 0으로 폴백된다") {
+                val (calc, repo) = createCalculator()
+                val presetByDeckId = mapOf(
+                    1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                )
+                every { repo.countNewCardsByDeckIds(any()) } returns emptyList()
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns emptyList()
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = presetByDeckId,
+                    dayCutoffHour = 0,
+                )
+
+                result[1L] shouldBe StudyTargetPoolCount(newCount = 0, reviewCount = 0)
+            }
+
+            it("presetByDeckId가 비어있으면 count 쿼리 호출 없이 빈 맵을 반환한다") {
+                val (calc, repo) = createCalculator()
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = emptyMap(),
+                    dayCutoffHour = 0,
+                )
+
+                result.shouldBeEmpty()
+                verify(exactly = 0) { repo.countNewCardsByDeckIds(any()) }
+                verify(exactly = 0) { repo.countReviewCardsByDeckIds(any(), any()) }
+            }
+
+            it("반환된 키 집합은 presetByDeckId의 키 집합과 같다") {
+                val (calc, repo) = createCalculator()
+                val presetByDeckId = mapOf(
+                    1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE,
+                    2L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE,
+                    3L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE,
+                )
+                every { repo.countNewCardsByDeckIds(any()) } returns emptyList()
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns emptyList()
+
+                val result = calc.getTodayPools(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    presetByDeckId = presetByDeckId,
+                    dayCutoffHour = 0,
+                )
+
+                result.keys shouldBe presetByDeckId.keys
+            }
+        }
+
+        describe("getTodayPools - 04시 기준 cutoff nextSessionStart 시간 계산 (단건과 동일 규칙)") {
+            data class BatchTimezoneCase(
+                val requestedAt: String,
+                val timezone: ZoneId,
+                val expectedNextSessionStart: String,
+                val label: String,
+            )
+
+            val cases = sequenceOf(
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-18T19:00:00",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 18일 19:00 요청일 경우, KST 19일 04:00이 다음 세션 시작 시간이다",
+                ),
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-19T03:59:59",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-19T04:00:00",
+                    label = "KST 19일 03:59:59 요청(컷오프 1초 직전)일 경우, KST 19일 04:00이 다음 세션 시작 시간이다",
+                ),
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-19T04:00:00",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-20T04:00:00",
+                    label = "KST 19일 04:00 요청(컷오프 정각)일 경우, KST 20일 04:00이 다음 세션 시작 시간이다",
+                ),
+                BatchTimezoneCase(
+                    requestedAt = "2026-05-19T04:00:01",
+                    timezone = kstZoneId,
+                    expectedNextSessionStart = "2026-05-20T04:00:00",
+                    label = "KST 19일 04:00:01 요청(컷오프 1초 직후)일 경우, KST 20일 04:00이 다음 세션 시작 시간이다",
+                ),
+            )
+
+            withData(
+                nameFn = { it.label },
+                cases,
+            ) { case ->
+                val (calc, repo) = createCalculator()
+                every { repo.countNewCardsByDeckIds(any()) } returns emptyList()
+                every { repo.countReviewCardsByDeckIds(any(), any()) } returns emptyList()
+
+                calc.getTodayPools(
+                    now = LocalDateTime.parse(case.requestedAt).atZone(case.timezone).toInstant(),
+                    timezone = case.timezone,
+                    presetByDeckId = mapOf(1L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE),
+                    dayCutoffHour = 4, // 해당 timezone의 04:00 cutoff
+                )
+
+                verify(exactly = 1) {
+                    repo.countReviewCardsByDeckIds(
+                        deckIds = setOf(1L),
                         nextSessionStart = LocalDateTime.parse(case.expectedNextSessionStart).atZone(case.timezone).toInstant(),
                     )
                 }

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
@@ -301,6 +301,259 @@ class StudyServiceTest(
         }
     }
 
+    describe("getTodaySummaries") {
+
+        it("ACTIVE 상태인 오늘 세션이 있는 덱은 InProgress로 반환된다") {
+            val session = createSession(
+                status = StudySessionStatus.ACTIVE,
+                newStudied = 3,
+                reviewStudied = 5,
+            )
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val inProgress = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.InProgress>()
+            inProgress.session.sessionId shouldBe session.id
+            inProgress.session.newCardsStudied shouldBe 3
+            inProgress.session.reviewCardsStudied shouldBe 5
+            inProgress.session.estimatedTotal shouldBe (session.newCardsGoal + session.reviewCardsGoal)
+        }
+
+        it("COMPLETED 상태인 오늘 세션이 있는 덱은 Completed로 반환된다") {
+            val session = createSession(
+                status = StudySessionStatus.COMPLETED,
+                newStudied = 10,
+                reviewStudied = 10,
+            )
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val completed = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.Completed>()
+            completed.session.sessionId shouldBe session.id
+        }
+
+        it("어제의 ACTIVE 세션은 무시하고 pool 경로로 판정한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 5, reviewPerDay = 0))
+            createSession(status = StudySessionStatus.ACTIVE, startedAt = yesterday)
+            repeat(2) { i ->
+                createCls(cardId = (i + 1).toLong(), status = CardLearningStatus.NEW)
+            }
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val notStarted = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            notStarted.pool.newCount shouldBe 2
+        }
+
+        it("오늘 세션이라도 STOPPED 상태면 세션 없음으로 취급한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 0, reviewPerDay = 0))
+            createSession(status = StudySessionStatus.STOPPED, startedAt = baseNow)
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            result[DECK_ID] shouldBe TodayStudySessionState.RestDay
+        }
+
+        it("세션이 없고 학습 대상 카드가 있으면 정확한 pool 값의 NotStarted를 반환한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10))
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), status = CardLearningStatus.NEW)
+            }
+            repeat(2) { i ->
+                createCls(
+                    cardId = (100 + i).toLong(),
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = baseNow,
+                )
+            }
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val notStarted = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            notStarted.pool.newCount shouldBe 3
+            notStarted.pool.reviewCount shouldBe 2
+            notStarted.presetId shouldBe Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.id
+        }
+
+        it("세션이 없고 학습 대상 카드도 없으면 RestDay를 반환한다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10))
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            result[DECK_ID] shouldBe TodayStudySessionState.RestDay
+        }
+
+        it("학습 대상 카드 수가 preset의 perDay를 넘으면 perDay까지만 pool에 담긴다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(DECK_ID to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 2, reviewPerDay = 1))
+            repeat(5) { i ->
+                createCls(cardId = (i + 1).toLong(), status = CardLearningStatus.NEW)
+            }
+            repeat(3) { i ->
+                createCls(
+                    cardId = (100 + i).toLong(),
+                    status = CardLearningStatus.REVIEW,
+                    nextReviewAt = baseNow,
+                )
+            }
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(DECK_ID),
+            )
+
+            val notStarted = result[DECK_ID].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            notStarted.pool.newCount shouldBe 2
+            notStarted.pool.reviewCount shouldBe 1
+        }
+
+        it("여러 덱의 상태가 혼합되어도 입력한 모든 deckId가 결과 키로 반환된다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(
+                    3L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                    4L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10),
+                )
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE)
+            createSession(deckId = 2L, status = StudySessionStatus.COMPLETED)
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), deckId = 3L, status = CardLearningStatus.NEW)
+            }
+            // deckId=4L는 세션도 카드도 없음
+
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L, 3L, 4L),
+            )
+
+            result.keys shouldBe setOf(1L, 2L, 3L, 4L)
+            result[1L].shouldBeInstanceOf<TodayStudySessionState.InProgress>()
+            result[2L].shouldBeInstanceOf<TodayStudySessionState.Completed>()
+            result[3L].shouldBeInstanceOf<TodayStudySessionState.NotStarted>()
+            result[4L] shouldBe TodayStudySessionState.RestDay
+        }
+
+        it("모든 덱에 오늘 세션이 있으면 preset 배치 조회를 호출하지 않는다") {
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE)
+            createSession(deckId = 2L, status = StudySessionStatus.COMPLETED)
+
+            studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L),
+            )
+
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) }
+        }
+
+        it("세션이 없는 덱이 있어도 단건 preset 조회는 호출하지 않는다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(2L to Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 0, reviewPerDay = 0))
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE)
+
+            studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L),
+            )
+
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetByUser(any(), any()) }
+        }
+
+        it("같은 데이터에 대해 단건 getTodaySummary와 동일한 결과를 반환한다") {
+            val preset = Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 10, reviewPerDay = 10)
+            every { deckPresetApi.getLatestDeckPresetByUser(any(), any()) } returns preset
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns
+                mapOf(2L to preset, 3L to preset)
+            createSession(deckId = 1L, status = StudySessionStatus.ACTIVE, newStudied = 3) // InProgress
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), deckId = 2L, status = CardLearningStatus.NEW) // NotStarted
+            }
+            // deckId=3L는 세션도 카드도 없음 → RestDay
+
+            val batchResult = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = setOf(1L, 2L, 3L),
+            )
+
+            listOf(1L, 2L, 3L).forEach { deckId ->
+                batchResult[deckId] shouldBe studyService.getTodaySummary(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    deckId = deckId,
+                )
+            }
+        }
+
+        it("세션이 없는 덱에 preset이 연결되어 있지 않으면 IllegalStateException을 던진다") {
+            every { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) } returns emptyMap()
+
+            shouldThrow<IllegalStateException> {
+                studyService.getTodaySummaries(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    deckIds = setOf(DECK_ID),
+                )
+            }
+        }
+
+        it("deckIds가 비어있으면 외부 호출 없이 빈 맵을 반환한다") {
+            val result = studyService.getTodaySummaries(
+                now = baseNow,
+                timezone = kstZoneId,
+                userId = USER_ID,
+                deckIds = emptySet(),
+            )
+
+            result.shouldBeEmpty()
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetsByDeckId(any(), any()) }
+            verify(exactly = 0) { deckPresetApi.getLatestDeckPresetByUser(any(), any()) }
+        }
+    }
+
     describe("getLearningStates") {
 
         it("매칭되는 카드는 cardId 기준 맵으로 매핑되고, 매칭되지 않는 요소는 무시한다") {

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -371,4 +371,76 @@ class CardLearningStateRepositoryTest(
             count shouldBe 1
         }
     }
+
+    // TODO userId 필터 추가 시 격리 케이스 추가
+    describe("countNewCardsByDeckIds") {
+        it("덱별 NEW 카드 수가 deckId 기준으로 집계된다") {
+            repeat(3) { i ->
+                createCls(cardId = (i + 1).toLong(), deckId = 1L, status = CardLearningStatus.NEW)
+            }
+            repeat(5) { i ->
+                createCls(cardId = (10 + i + 1).toLong(), deckId = 2L, status = CardLearningStatus.NEW)
+            }
+
+            val result = cardLearningStateRepository.countNewCardsByDeckIds(
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 3L, 2L to 5L)
+        }
+
+        it("NEW 카드가 없는 덱은 결과에 행 자체가 없다") {
+            createCls(cardId = 1L, deckId = 1L, status = CardLearningStatus.NEW)
+
+            val result = cardLearningStateRepository.countNewCardsByDeckIds(
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.map { it.deckId } shouldBe listOf(1L)
+        }
+
+        it("REVIEW 상태 카드와 soft delete된 NEW 카드는 집계되지 않는다") {
+            createCls(cardId = 1L, deckId = 1L, status = CardLearningStatus.NEW)
+            createCls(cardId = 2L, deckId = 1L, status = CardLearningStatus.REVIEW, nextReviewAt = beforeCutoff)
+            val deleted = createCls(cardId = 3L, deckId = 1L, status = CardLearningStatus.NEW)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.countNewCardsByDeckIds(
+                deckIds = setOf(1L),
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
+        }
+    }
+
+    // TODO userId 필터 추가 시 격리 케이스 추가
+    describe("countReviewCardsByDeckIds") {
+        it("nextReviewAt이 nextSessionStart 직전(1초 전)인 카드는 포함되고, 동일한 카드는 제외된다") {
+            createCls(cardId = 1L, deckId = 1L, nextReviewAt = nextSessionStart.minusSeconds(1))
+            createCls(cardId = 2L, deckId = 2L, nextReviewAt = nextSessionStart)
+
+            val result = cardLearningStateRepository.countReviewCardsByDeckIds(
+                deckIds = setOf(1L, 2L),
+                nextSessionStart = nextSessionStart,
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
+        }
+
+        it("NEW 상태 카드와 soft delete된 REVIEW 카드는 집계되지 않는다") {
+            createCls(cardId = 1L, deckId = 1L, nextReviewAt = beforeCutoff)
+            createCls(cardId = 2L, deckId = 1L, status = CardLearningStatus.NEW, nextReviewAt = beforeCutoff)
+            val deleted = createCls(cardId = 3L, deckId = 1L, nextReviewAt = beforeCutoff)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.countReviewCardsByDeckIds(
+                deckIds = setOf(1L),
+                nextSessionStart = nextSessionStart,
+            )
+
+            result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
+        }
+    }
 })

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
@@ -5,11 +5,13 @@ import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
 import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 @ApplicationModuleTest(extraIncludes = ["common"])
 @Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
@@ -23,16 +25,20 @@ class StudySessionRepositoryTest(
 
     fun saveSession(
         status: StudySessionStatus = StudySessionStatus.ACTIVE,
+        userId: Long = 1L,
+        deckId: Long = 1L,
+        startedAt: Instant = now,
+        dayCutoffHour: Int = 4,
     ): StudySession =
         studySessionRepository.save(
             StudySession(
-                userId = 1L,
-                deckId = 1L,
+                userId = userId,
+                deckId = deckId,
                 status = status,
                 studyType = StudyType.DAILY,
-                startedAt = now,
+                startedAt = startedAt,
                 timezone = kstZoneId,
-                dayCutoffHour = 4,
+                dayCutoffHour = dayCutoffHour,
                 deckPresetIdSnapshot = 1L,
             ),
         )
@@ -54,6 +60,73 @@ class StudySessionRepositoryTest(
 
             affected shouldBe 0
             studySessionRepository.findById(session.id).orElseThrow().status shouldBe StudySessionStatus.COMPLETED
+        }
+    }
+
+    describe("findLatestByUserIdAndDeckIdIn") {
+        val yesterday = now.minus(1, ChronoUnit.DAYS)
+
+        it("덱별로 startedAt이 가장 최신인 세션 1건씩만 반환한다") {
+            saveSession(deckId = 1L, startedAt = yesterday)
+            val latestOfDeck1 = saveSession(deckId = 1L, startedAt = now)
+            saveSession(deckId = 2L, startedAt = yesterday)
+            val latestOfDeck2 = saveSession(deckId = 2L, startedAt = now)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.map { it.id }.shouldContainExactlyInAnyOrder(listOf(latestOfDeck1.id, latestOfDeck2.id))
+        }
+
+        it("같은 덱에 startedAt이 동일한 세션이 여러 건이면 id가 큰 세션만 반환한다") {
+            // uk_session_per_day(user, deck, session_date) 때문에 같은 날짜의 동률은 존재할 수 없어,
+            // dayCutoffHour를 다르게 줘서 session_date가 갈리는 startedAt 동률을 재현한다
+            saveSession(deckId = 1L, startedAt = now, dayCutoffHour = 11)
+            val laterInserted = saveSession(deckId = 1L, startedAt = now, dayCutoffHour = 4)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L),
+            )
+
+            result.map { it.id } shouldBe listOf(laterInserted.id)
+        }
+
+        it("다른 userId의 같은 deckId 세션은 더 최신이어도 결과에 영향을 주지 않는다") {
+            val mySession = saveSession(userId = 1L, deckId = 1L, startedAt = yesterday)
+            saveSession(userId = 2L, deckId = 1L, startedAt = now)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L),
+            )
+
+            result.map { it.id } shouldBe listOf(mySession.id)
+        }
+
+        it("deckIds에 포함되지 않은 덱의 세션은 반환되지 않는다") {
+            val sessionOfDeck1 = saveSession(deckId = 1L)
+            saveSession(deckId = 2L)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L),
+            )
+
+            result.map { it.id } shouldBe listOf(sessionOfDeck1.id)
+        }
+
+        it("세션이 없는 덱은 결과에 행 자체가 없다") {
+            saveSession(deckId = 1L)
+
+            val result = studySessionRepository.findLatestByUserIdAndDeckIdIn(
+                userId = 1L,
+                deckIds = setOf(1L, 2L),
+            )
+
+            result.map { it.deckId } shouldBe listOf(1L)
         }
     }
 })


### PR DESCRIPTION
## 📌 Related Issue
Closes #

## 📝 Changes
`홈 화면 덱 목록`과 `덱 카드 목록`에 필요한 일일학습 정보를 덱 조회 경로에 함께 반환할 수 있도록 endpoint 추가

### 홈 덱 목록 + 세션 진행도 (`GET /v1/decks`)
- 덱 목록과 각 덱의 오늘 학습 진행도(`상태` + `목표/학습 장 수`)를 반환
- 덱마다 진행도를 따로 조회하면 덱 수에 비례해 쿼리가 늘어나, 고정된 4개의 쿼리로 한 번에 조회

### 덱 카드 목록 (`GET /v2/decks/{deckId}/cards`)
- 카드 본문 + 학습 상태(NEW/REVIEW/HARD badge, 복습 수)를 반환
- 기존 카드 목록(v1)은 학습 상태가 없어, v2를 추가하고 v1은 `@Deprecated`

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
