### PR TITLE
[Feat] 연속 학습일 기능 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/study/DailyStudyCompletedEvent.kt
+++ b/src/main/kotlin/com/whatever/caro/study/DailyStudyCompletedEvent.kt
@@ -2,7 +2,7 @@ package com.whatever.caro.study
 
 import java.time.LocalDate
 
-data class DailyStudyCompletedEvnet(
+data class DailyStudyCompletedEvent(
     val userId: Long,
     val studyDate: LocalDate,
 )

--- a/src/main/kotlin/com/whatever/caro/study/DailyStudyCompletedEvnet.kt
+++ b/src/main/kotlin/com/whatever/caro/study/DailyStudyCompletedEvnet.kt
@@ -1,0 +1,8 @@
+package com.whatever.caro.study
+
+import java.time.LocalDate
+
+data class DailyStudyCompletedEvnet(
+    val userId: Long,
+    val studyDate: LocalDate,
+)

--- a/src/main/kotlin/com/whatever/caro/study/StreakType.kt
+++ b/src/main/kotlin/com/whatever/caro/study/StreakType.kt
@@ -1,0 +1,6 @@
+package com.whatever.caro.study
+
+enum class StreakType {
+    DAILY_STUDY,
+    REST_DAY,
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
@@ -3,6 +3,7 @@ package com.whatever.caro.study.internal
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.CardLearningStatus
+import com.whatever.caro.study.DailyStudyCompletedEvnet
 import com.whatever.caro.study.ReviewType
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.exception.SessionExpiredException
@@ -12,6 +13,7 @@ import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepos
 import com.whatever.caro.study.internal.studysession.ReviewLog
 import com.whatever.caro.study.internal.studysession.ReviewLogRepository
 import com.whatever.caro.study.internal.studysession.StudySessionRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -22,6 +24,7 @@ class EvaluationService(
     private val deckPresetApi: DeckPresetApi,
     private val cardLearningStateRepository: CardLearningStateRepository,
     private val reviewLogRepository: ReviewLogRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun evaluate(
@@ -90,7 +93,14 @@ class EvaluationService(
             session.updateStudiedCard(reviewLog.reviewType)
             reviewLog
         }
-        session.completeIfGoalAchieved(now)
+        if (session.completeIfGoalAchieved(now)) {
+            applicationEventPublisher.publishEvent(
+                DailyStudyCompletedEvnet(
+                    userId = userId,
+                    studyDate = session.sessionDate,
+                ),
+            )
+        }
 
         reviewLogRepository.saveAll(newReviewLogs)
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
@@ -3,7 +3,7 @@ package com.whatever.caro.study.internal
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.CardLearningStatus
-import com.whatever.caro.study.DailyStudyCompletedEvnet
+import com.whatever.caro.study.DailyStudyCompletedEvent
 import com.whatever.caro.study.ReviewType
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.exception.SessionExpiredException
@@ -95,7 +95,7 @@ class EvaluationService(
         }
         if (session.completeIfGoalAchieved(now)) {
             applicationEventPublisher.publishEvent(
-                DailyStudyCompletedEvnet(
+                DailyStudyCompletedEvent(
                     userId = userId,
                     studyDate = session.sessionDate,
                 ),

--- a/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepository.kt
@@ -1,5 +1,6 @@
 package com.whatever.caro.study.internal.cardlearningstate
 
+import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.internal.DeckCardCount
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -127,4 +128,46 @@ interface CardLearningStateRepository : JpaRepository<CardLearningState, Long> {
         deckIds: Collection<Long>,
         nextSessionStart: Instant,
     ): List<DeckCardCount>
+
+    /**
+     * 사용자에게 학습 대상 NEW 카드 존재 여부.
+     */
+    fun existsNewCardByUser(
+        userId: Long,
+    ): Boolean =
+        existsByUserIdAndStatusAndDeletedAtIsNull(
+            userId = userId,
+            status = CardLearningStatus.NEW,
+        )
+
+    /**
+     * 사용자에게 오늘 복습 대상(REVIEW, next_review_at < nextSessionStart) 카드 존재 여부
+     */
+    fun existsTodayReviewCardByUser(
+        userId: Long,
+        nextSessionStart: Instant,
+    ): Boolean =
+        existsByUserIdAndStatusAndNextReviewAtLessThanAndDeletedAtIsNull(
+            userId = userId,
+            status = CardLearningStatus.REVIEW,
+            nextReviewAt = nextSessionStart,
+        )
+
+    /**
+     * 사용자에게 카드가 하나라도 존재하는지 여부.
+     */
+    fun existsByUserIdAndDeletedAtIsNull(
+        userId: Long,
+    ): Boolean
+
+    fun existsByUserIdAndStatusAndDeletedAtIsNull(
+        userId: Long,
+        status: CardLearningStatus,
+    ): Boolean
+
+    fun existsByUserIdAndStatusAndNextReviewAtLessThanAndDeletedAtIsNull(
+        userId: Long,
+        status: CardLearningStatus,
+        nextReviewAt: Instant,
+    ): Boolean
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/StreakEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/StreakEventListener.kt
@@ -1,0 +1,21 @@
+package com.whatever.caro.study.internal.event
+
+import com.whatever.caro.study.DailyStudyCompletedEvnet
+import com.whatever.caro.study.internal.streak.StreakService
+import org.springframework.modulith.events.ApplicationModuleListener
+import org.springframework.stereotype.Component
+
+@Component
+class StreakEventListener(
+    private val streakService: StreakService,
+) {
+    @ApplicationModuleListener
+    fun onDailyStudyCompleted(
+        event: DailyStudyCompletedEvnet,
+    ) {
+        streakService.recordStudied(
+            userId = event.userId,
+            studyDate = event.studyDate,
+        )
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/event/StreakEventListener.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/event/StreakEventListener.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal.event
 
-import com.whatever.caro.study.DailyStudyCompletedEvnet
+import com.whatever.caro.study.DailyStudyCompletedEvent
 import com.whatever.caro.study.internal.streak.StreakService
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
@@ -11,7 +11,7 @@ class StreakEventListener(
 ) {
     @ApplicationModuleListener
     fun onDailyStudyCompleted(
-        event: DailyStudyCompletedEvnet,
+        event: DailyStudyCompletedEvent,
     ) {
         streakService.recordStudied(
             userId = event.userId,

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/ExistsBasedRestDayCheckService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/ExistsBasedRestDayCheckService.kt
@@ -1,0 +1,54 @@
+package com.whatever.caro.study.internal.streak
+
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * EXISTS 쿼리 기반 휴식일 판정.
+ */
+@Component
+class ExistsBasedRestDayCheckService(
+    private val cardLearningStateRepository: CardLearningStateRepository,
+) : RestDayCheckService {
+
+    @Transactional(readOnly = true)
+    override fun isRestDay(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+        dayCutoffHour: Int,
+    ): Boolean {
+        val newCardExists = cardLearningStateRepository.existsNewCardByUser(userId)
+        if (newCardExists) {
+            return false
+        }
+        val reviewCardExists = cardLearningStateRepository.existsTodayReviewCardByUser(
+            userId = userId,
+            nextSessionStart = getNextSessionStart(now, timezone, dayCutoffHour),
+        )
+        if (reviewCardExists) {
+            return false
+        }
+
+        return cardLearningStateRepository.existsByUserIdAndDeletedAtIsNull(userId)
+    }
+
+    /**
+     * dayCutoff를 반영한 "오늘"의 다음 세션 시작 시각.
+     */
+    private fun getNextSessionStart(
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ): Instant =
+        now.atZone(timezone)
+            .minusHours(dayCutoffHour.toLong())
+            .toLocalDate()
+            .plusDays(1)
+            .atTime(dayCutoffHour, 0)
+            .atZone(timezone)
+            .toInstant()
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/RestDayCheckService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/RestDayCheckService.kt
@@ -1,0 +1,19 @@
+package com.whatever.caro.study.internal.streak
+
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * streak용 휴식일 판정 추상화.
+ *
+ * "사용자가 오늘 학습할 카드가 하나도 없는가"를 반환한다.
+ * 카드가 전혀 없을 경우 휴식일이 아니다.
+ */
+interface RestDayCheckService {
+    fun isRestDay(
+        now: Instant,
+        timezone: ZoneId,
+        userId: Long,
+        dayCutoffHour: Int,
+    ): Boolean
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakService.kt
@@ -1,0 +1,189 @@
+package com.whatever.caro.study.internal.streak
+
+import com.whatever.caro.study.StreakType
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class StreakService(
+    private val streakStateRepository: StreakStateRepository,
+    private val studyDayRepository: StudyDayRepository,
+) {
+    /**
+     * "오늘 기준" streak을 반환한다.
+     *
+     * streak 끊김 여부는 `streak이 마지막으로 기록된 시점`과 `timezone 기준 오늘`로 판단하므로,
+     * timezone이 바뀌었을 경우 [sync]로 갱신한 뒤 조회해야 정확하다.
+     */
+    @Transactional(readOnly = true)
+    fun getStreak(
+        userId: Long,
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ): Int {
+        val streakState = streakStateRepository.findByUserId(userId = userId)
+            ?: return 0
+
+        val currentDate = toStreakDate(now, timezone, dayCutoffHour)
+        if (isStreakAlive(streakState.lastRecordedDate, currentDate)) {
+            return streakState.currentStreak
+        }
+
+        return 0
+    }
+
+    /**
+     * 앱 진입 등 상호작용 시점에 호출되어, 저장된 current streak을 "오늘 기준" 값으로 동기화한다.
+     * streak 끊김은 학습 기록이 없는 것으로 판단하기 때문에,
+     * current streak을 0으로 persist하는 것은 이 메서드의 책임이다.
+     *
+     * timezone이 미래로 이동(예: UTC-12 → UTC+14)해 sync되면 streak은 끊긴다.
+     * timezone이 과거로 이동(예: UTC+14 → UTC-12)해 sync되면 로그에서 streak을 재계산한다.
+     */
+    @Transactional
+    fun sync(
+        userId: Long,
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ) {
+        val streakState = streakStateRepository.findByUserIdForUpdate(userId = userId)
+            ?: return
+        val daysDesc = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId)
+        if (daysDesc.isEmpty()) {
+            return
+        }
+
+        val lastRecordedDate = daysDesc.first().studyDate
+        val currentDate = toStreakDate(now, timezone, dayCutoffHour)
+
+        val currentStreak = if (isStreakAlive(streakState.lastRecordedDate, currentDate)) {
+            computeStreak(daysDesc = daysDesc)
+        } else {
+            resolveGap(
+                userId = userId,
+                previousDate = streakState.lastRecordedDate,
+                currentDate = currentDate,
+            )
+            0
+        }
+
+        streakState.updateCurrentStreak(
+            currentStreak = currentStreak,
+            lastRecordedDate = lastRecordedDate,
+        )
+        streakStateRepository.save(streakState)
+    }
+
+    @Transactional
+    fun recordStudied(
+        userId: Long,
+        studyDate: LocalDate,
+    ) {
+        val effectedRows = studyDayRepository.upsertStudied(
+            userId = userId,
+            studyDate = studyDate,
+        )
+        when (effectedRows) {
+            0 -> return
+            else -> reconcile(userId = userId, recordedDate = studyDate)
+        }
+    }
+
+    @Transactional
+    fun recordRest(
+        userId: Long,
+        restDate: LocalDate,
+    ) {
+        val effectedRows = studyDayRepository.insertRestIfAbsent(
+            userId = userId,
+            restDate = restDate,
+        )
+        when (effectedRows) {
+            0, 2 -> return
+            else -> reconcile(userId = userId, recordedDate = restDate)
+        }
+    }
+
+    private fun reconcile(
+        userId: Long,
+        recordedDate: LocalDate,
+    ) {
+        val streakState = streakStateRepository.findByUserIdForUpdate(userId = userId)
+            ?: StreakState(
+                userId = userId,
+                lastRecordedDate = recordedDate,
+            )
+
+        if (isStreakAlive(streakState.lastRecordedDate, recordedDate).not()) {
+            resolveGap(
+                userId = userId,
+                previousDate = streakState.lastRecordedDate,
+                currentDate = recordedDate,
+            )
+        }
+
+        val daysDesc = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId)
+        streakState.updateCurrentStreak(
+            currentStreak = computeStreak(daysDesc),
+            lastRecordedDate = daysDesc.first().studyDate, // 항상 최신 study date를 기록
+        )
+        streakStateRepository.save(streakState)
+    }
+
+    private fun computeStreak(
+        daysDesc: List<StudyDay>,
+    ): Int {
+        if (daysDesc.isEmpty()) {
+            return 0
+        }
+
+        var streakCount = 0
+        var expectedDate = daysDesc.first().studyDate
+        for (day in daysDesc) {
+            if (day.studyDate != expectedDate) {
+                break
+            }
+            if (day.streakType == StreakType.DAILY_STUDY) {
+                streakCount++
+            }
+            expectedDate = expectedDate.minusDays(1)
+        }
+
+        return streakCount
+    }
+
+    private fun resolveGap(
+        userId: Long,
+        previousDate: LocalDate,
+        currentDate: LocalDate,
+    ) {
+        if (isStreakAlive(previousDate, currentDate)) {
+            return
+        }
+
+        // 현재는 Timezone 이동으로 인한 시간 끊김 보정하지 않음
+        logger.info {
+            "Streak gap detected. userId=$userId, previousDate=$previousDate, currentDate=$currentDate"
+        }
+    }
+
+    private fun isStreakAlive(
+        lastRecordedDate: LocalDate,
+        currentDate: LocalDate,
+    ): Boolean = ChronoUnit.DAYS.between(lastRecordedDate, currentDate) <= 1
+
+    private fun toStreakDate(
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ): LocalDate = now.atZone(timezone).minusHours(dayCutoffHour.toLong()).toLocalDate()
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakService.kt
@@ -15,7 +15,42 @@ private val logger = KotlinLogging.logger {}
 class StreakService(
     private val streakStateRepository: StreakStateRepository,
     private val studyDayRepository: StudyDayRepository,
+    private val restDayCheckService: RestDayCheckService,
 ) {
+    @Transactional
+    fun syncWithRestDayCheck(
+        userId: Long,
+        now: Instant,
+        timezone: ZoneId,
+        dayCutoffHour: Int,
+    ) {
+        val today = toStreakDate(now, timezone, dayCutoffHour)
+        val alreadyRecorded = studyDayRepository.existsByUserIdAndStudyDate(
+            userId = userId,
+            studyDate = today,
+        )
+
+        val isRestDay = !alreadyRecorded && restDayCheckService.isRestDay(
+            userId = userId,
+            now = now,
+            timezone = timezone,
+            dayCutoffHour = dayCutoffHour,
+        )
+
+        if (isRestDay) {
+            recordRest(
+                userId = userId,
+                restDate = today,
+            )
+        }
+        sync(
+            userId = userId,
+            now = now,
+            timezone = timezone,
+            dayCutoffHour = dayCutoffHour,
+        )
+    }
+
     /**
      * "오늘 기준" streak을 반환한다.
      *

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakState.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakState.kt
@@ -1,0 +1,35 @@
+package com.whatever.caro.study.internal.streak
+
+import com.whatever.caro.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "streak_states")
+class StreakState(
+    @Column(name = "user_id", nullable = false, unique = true)
+    val userId: Long,
+
+    @Column(name = "current_streak", nullable = false)
+    var currentStreak: Int = 0,
+
+    @Column(name = "last_recorded_date", nullable = false)
+    var lastRecordedDate: LocalDate,
+) : BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    fun updateCurrentStreak(
+        currentStreak: Int,
+        lastRecordedDate: LocalDate,
+    ) {
+        this.currentStreak = currentStreak
+        this.lastRecordedDate = lastRecordedDate
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakStateRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakStateRepository.kt
@@ -1,0 +1,23 @@
+package com.whatever.caro.study.internal.streak
+
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+
+interface StreakStateRepository : JpaRepository<StreakState, Long> {
+    fun findByUserId(
+        userId: Long,
+    ): StreakState?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select ss from StreakState ss
+        where ss.userId = :userId
+        """,
+    )
+    fun findByUserIdForUpdate(
+        userId: Long,
+    ): StreakState?
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StudyDay.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StudyDay.kt
@@ -1,0 +1,31 @@
+package com.whatever.caro.study.internal.streak
+
+import com.whatever.caro.common.entity.BaseTimeEntity
+import com.whatever.caro.study.StreakType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "study_days")
+class StudyDay(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "streak_type", nullable = false)
+    val streakType: StreakType,
+
+    @Column(name = "study_date", nullable = false)
+    val studyDate: LocalDate,
+) : BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StudyDayRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StudyDayRepository.kt
@@ -1,0 +1,49 @@
+package com.whatever.caro.study.internal.streak
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
+
+interface StudyDayRepository : JpaRepository<StudyDay, Long> {
+    @Modifying(
+        flushAutomatically = true,
+        clearAutomatically = true,
+    )
+    @Query(
+        nativeQuery = true,
+        value = """
+        insert into study_days (user_id, streak_type, study_date, created_at, updated_at)
+        values (:userId, 'DAILY_STUDY', :studyDate, NOW(6), NOW(6))
+        on duplicate key update
+            streak_type = 'DAILY_STUDY',
+            updated_at = NOW(6)
+        """,
+    )
+    fun upsertStudied(
+        userId: Long,
+        studyDate: LocalDate,
+    ): Int
+
+    @Modifying(
+        flushAutomatically = true,
+        clearAutomatically = true,
+    )
+    @Query(
+        nativeQuery = true,
+        value = """
+        insert into study_days (user_id, study_date, streak_type, created_at, updated_at)
+        values (:userId, :restDate, 'REST_DAY', NOW(6), NOW(6))
+        on duplicate key update
+            updated_at = NOW(6)
+      """,
+    )
+    fun insertRestIfAbsent(
+        userId: Long,
+        restDate: LocalDate,
+    ): Int
+
+    fun findAllByUserIdOrderByStudyDateDesc(
+        userId: Long,
+    ): List<StudyDay>
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StudyDayRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StudyDayRepository.kt
@@ -46,4 +46,9 @@ interface StudyDayRepository : JpaRepository<StudyDay, Long> {
     fun findAllByUserIdOrderByStudyDateDesc(
         userId: Long,
     ): List<StudyDay>
+
+    fun existsByUserIdAndStudyDate(
+        userId: Long,
+        studyDate: LocalDate,
+    ): Boolean
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/studysession/StudySession.kt
@@ -116,12 +116,18 @@ class StudySession(
 
     fun completeIfGoalAchieved(
         now: Instant,
-    ) {
+    ): Boolean {
+        if (status != StudySessionStatus.ACTIVE) {
+            return false
+        }
+
         if ((newCardsStudied >= newCardsGoal) && (reviewCardsStudied >= reviewCardsGoal)) {
             complete(now)
+            if (newCardsGoal == 0 && reviewCardsGoal == 0) {
+                logger.debug { "All cards deleted. Session status updated: $status. sessionId: $id" }
+            }
+            return true
         }
-        if (newCardsGoal == 0 && reviewCardsGoal == 0) {
-            logger.debug { "All cards deleted. Session status updated: $status. sessionId: $id" }
-        }
+        return false
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
@@ -1,0 +1,56 @@
+package com.whatever.caro.study.internal.web
+
+import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.study.internal.streak.StreakService
+import com.whatever.caro.study.internal.web.response.StreakResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+@Tag(name = "Streak", description = "연속 학습(streak)")
+@RestController
+@RequestMapping("/v1/streaks")
+class StreakController(
+    private val clock: Clock,
+    private val streakService: StreakService,
+) {
+
+    @Operation(
+        summary = "현재 streak 조회",
+        description = "오늘이 휴식일(모든 학습 활성 덱의 due=0)이면 휴식일을 기록한 뒤 현재 streak을 반환한다.",
+    )
+    @GetMapping
+    fun getStreak(
+        @RequestHeader("Client-Timezone") timezone: ZoneId,
+    ): ResponseEntity<StreakResponse> {
+        val now = Instant.now(clock)
+        val currentStreak = streakService.getStreak(
+            userId = SecurityUtil.currentUser().userId,
+            now = now,
+            timezone = timezone,
+            dayCutoffHour = 0,
+        )
+        return ResponseEntity.ok(StreakResponse(currentStreak = currentStreak))
+    }
+
+    @PostMapping("/sync")
+    fun syncStreak(
+        @RequestHeader("Client-Timezone") timezone: ZoneId,
+    ) {
+        val now = Instant.now(clock)
+        streakService.syncWithRestDayCheck(
+            userId = SecurityUtil.currentUser().userId,
+            now = now,
+            timezone = timezone,
+            dayCutoffHour = 0,
+        )
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/response/StreakResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/response/StreakResponse.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro.study.internal.web.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "연속 학습(streak) 응답")
+data class StreakResponse(
+    @get:Schema(description = "오늘 기준 현재 연속 학습일 수", example = "5")
+    val currentStreak: Int,
+)

--- a/src/main/resources/db/migration/study/V7__init_streak_table.sql
+++ b/src/main/resources/db/migration/study/V7__init_streak_table.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS `streak_states` (
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id             BIGINT  NOT NULL,
+    current_streak      INT     NOT NULL DEFAULT 0  COMMENT '연속 학습 카운트',
+    last_recorded_date  DATE    NOT NULL            COMMENT '마지막으로 기록된 날짜(타임존 변환 없이 원본 그대로)',
+
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+
+    UNIQUE KEY uk_streak_states_user (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='스트릭 상태. USER와 1:1';
+
+CREATE TABLE IF NOT EXISTS `study_days` (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id     BIGINT      NOT NULL,
+    streak_type VARCHAR(20) NOT NULL COMMENT '스트릭 종류',
+    study_date  DATE        NOT NULL COMMENT '학습일(타임존 변환 없이 원본 그대로)',
+
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+
+    UNIQUE KEY uk_user_study_date (user_id, study_date),
+
+    CONSTRAINT chk_streak_type CHECK (streak_type IN ('DAILY_STUDY', 'REST_DAY'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='스트릭을 구성하는 학습일.';

--- a/src/main/resources/db/migration/study/V8__card_learning_state_add_indexes.sql
+++ b/src/main/resources/db/migration/study/V8__card_learning_state_add_indexes.sql
@@ -1,0 +1,9 @@
+-- card_learning_states 복합 인덱스.
+
+-- 덱 일일학습 집계 및 조회
+CREATE INDEX idx_cls_deck_status_deleted_nextreview
+    ON card_learning_states (deck_id, status, deleted_at, next_review_at);
+
+-- user 기준 휴식일 EXISTS
+CREATE INDEX idx_cls_user_status_deleted_nextreview
+    ON card_learning_states (user_id, status, deleted_at, next_review_at);

--- a/src/main/resources/db/migration/study/V8__card_learning_state_add_indexes.sql
+++ b/src/main/resources/db/migration/study/V8__card_learning_state_add_indexes.sql
@@ -6,4 +6,4 @@ CREATE INDEX idx_cls_deck_status_deleted_nextreview
 
 -- user 기준 휴식일 EXISTS
 CREATE INDEX idx_cls_user_status_deleted_nextreview
-    ON card_learning_states (user_id, status, deleted_at, next_review_at);
+    ON card_learning_states (user_id, deleted_at, status, next_review_at);

--- a/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
@@ -12,6 +12,9 @@ import com.whatever.caro.study.exception.SessionNotActiveException
 import com.whatever.caro.study.exception.SessionNotFoundException
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningState
 import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import com.whatever.caro.study.internal.streak.RestDayCheckService
+import com.whatever.caro.study.internal.streak.StreakStateRepository
+import com.whatever.caro.study.internal.streak.StudyDayRepository
 import com.whatever.caro.study.internal.studysession.ReviewLogRepository
 import com.whatever.caro.study.internal.studysession.StudySession
 import com.whatever.caro.study.internal.studysession.StudySessionRepository
@@ -38,12 +41,16 @@ import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
 // Kotest DescribeSpec의 생성자 주입에서는 @MockitoBean/@TestBean 사용이 제한적이라 @TestConfiguration + @Primary로 Bean 교체
-// card 모듈의 DeckPresetApi 만 mock 으로 대체하고 나머지 레포지토리는 실제 JPA 를 사용
+// card 모듈의 DeckPresetApi와 study의 RestDayCheckService를 mock 으로 대체하고 나머지 레포지토리는 실제 JPA 를 사용
 @TestConfiguration
 class MockDeckPresetApiConfig {
     @Bean
     @Primary
     fun deckPresetApi(): DeckPresetApi = mockk(relaxed = true)
+
+    @Bean
+    @Primary
+    fun restDayCheckService(): RestDayCheckService = mockk(relaxed = true)
 }
 
 @ApplicationModuleTest(extraIncludes = ["common"])
@@ -54,6 +61,8 @@ class EvaluationServiceTest(
     private val studySessionRepository: StudySessionRepository,
     private val cardLearningStateRepository: CardLearningStateRepository,
     private val reviewLogRepository: ReviewLogRepository,
+    private val studyDayRepository: StudyDayRepository,
+    private val streakStateRepository: StreakStateRepository,
 ) : DescribeSpec({
 
     val kstZoneId = ZoneId.of("Asia/Seoul")
@@ -65,6 +74,8 @@ class EvaluationServiceTest(
         reviewLogRepository.deleteAllInBatch()
         studySessionRepository.deleteAllInBatch()
         cardLearningStateRepository.deleteAllInBatch()
+        studyDayRepository.deleteAllInBatch()
+        streakStateRepository.deleteAllInBatch()
         clearMocks(deckPresetApi)
     }
 

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -501,7 +501,7 @@ class CardLearningStateRepositoryTest(
                 cardId = 1L,
                 userId = 1L,
                 status = CardLearningStatus.REVIEW,
-                nextReviewAt = nextSessionStart.minusSeconds(1),  // nextReviewAt이 nextSessionStart 직전(1초 전)
+                nextReviewAt = nextSessionStart.minusSeconds(1), // nextReviewAt이 nextSessionStart 직전(1초 전)
             )
 
             val result = cardLearningStateRepository.existsTodayReviewCardByUser(
@@ -527,7 +527,6 @@ class CardLearningStateRepositoryTest(
 
             result shouldBe false
         }
-
 
         it("soft delete된 REVIEW 카드는 제외된다") {
             val deleted = createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.REVIEW, nextReviewAt = beforeCutoff)

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -443,4 +443,148 @@ class CardLearningStateRepositoryTest(
             result.associate { it.deckId to it.count } shouldBe mapOf(1L to 1L)
         }
     }
+
+    describe("existsNewCardByUser") {
+        it("user에게 NEW 카드가 하나라도 있으면 true를 반환한다") {
+            createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.NEW)
+
+            val result = cardLearningStateRepository.existsNewCardByUser(userId = 1L)
+
+            result shouldBe true
+        }
+
+        it("NEW 카드가 없으면 false를 반환한다") {
+            createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.REVIEW, nextReviewAt = beforeCutoff)
+
+            val result = cardLearningStateRepository.existsNewCardByUser(userId = 1L)
+
+            result shouldBe false
+        }
+
+        it("soft delete된 NEW 카드는 제외된다") {
+            val deleted = createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.NEW)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.existsNewCardByUser(userId = 1L)
+
+            result shouldBe false
+        }
+
+        it("다른 user의 NEW 카드는 제외된다") {
+            createCls(cardId = 1L, userId = 2L, status = CardLearningStatus.NEW)
+
+            val result = cardLearningStateRepository.existsNewCardByUser(userId = 1L)
+            result shouldBe false
+        }
+    }
+
+    describe("existsTodayReviewCardByUser") {
+        it("REVIEW 카드가 없다면 false를 반환한다") {
+            createCls(
+                cardId = 1L,
+                userId = 1L,
+                status = CardLearningStatus.NEW,
+                nextReviewAt = beforeCutoff,
+            )
+
+            val result = cardLearningStateRepository.existsTodayReviewCardByUser(
+                userId = 1L,
+                nextSessionStart = nextSessionStart,
+            )
+
+            result shouldBe false
+        }
+
+        it("오늘 학습에 포함된 카드가 존재한다면 true를 반환한다") {
+            createCls(
+                cardId = 1L,
+                userId = 1L,
+                status = CardLearningStatus.REVIEW,
+                nextReviewAt = nextSessionStart.minusSeconds(1),  // nextReviewAt이 nextSessionStart 직전(1초 전)
+            )
+
+            val result = cardLearningStateRepository.existsTodayReviewCardByUser(
+                userId = 1L,
+                nextSessionStart = nextSessionStart,
+            )
+
+            result shouldBe true
+        }
+
+        it("오늘 학습 범위에 포함되는 카드가 없다면 false를 반환한다") {
+            createCls(
+                cardId = 1L,
+                userId = 1L,
+                status = CardLearningStatus.REVIEW,
+                nextReviewAt = nextSessionStart,
+            )
+
+            val result = cardLearningStateRepository.existsTodayReviewCardByUser(
+                userId = 1L,
+                nextSessionStart = nextSessionStart,
+            )
+
+            result shouldBe false
+        }
+
+
+        it("soft delete된 REVIEW 카드는 제외된다") {
+            val deleted = createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.REVIEW, nextReviewAt = beforeCutoff)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.existsTodayReviewCardByUser(
+                userId = 1L,
+                nextSessionStart = nextSessionStart,
+            )
+
+            result shouldBe false
+        }
+
+        it("다른 user의 REVIEW 카드는 제외된다") {
+            createCls(cardId = 1L, userId = 2L, status = CardLearningStatus.REVIEW, nextReviewAt = beforeCutoff)
+
+            val result = cardLearningStateRepository.existsTodayReviewCardByUser(
+                userId = 1L,
+                nextSessionStart = nextSessionStart,
+            )
+
+            result shouldBe false
+        }
+    }
+
+    describe("existsByUserIdAndDeletedAtIsNull") {
+        it("user에게 학습 카드가 하나라도 있으면 true를 반환한다") {
+            createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.NEW)
+
+            val result = cardLearningStateRepository.existsByUserIdAndDeletedAtIsNull(userId = 1L)
+
+            result shouldBe true
+        }
+
+        it("카드가 없으면 false를 반환한다") {
+            val result = cardLearningStateRepository.existsByUserIdAndDeletedAtIsNull(userId = 1L)
+
+            result shouldBe false
+        }
+
+        it("soft delete된 카드만 있으면 false를 반환한다") {
+            val deleted = createCls(cardId = 1L, userId = 1L, status = CardLearningStatus.NEW)
+            deleted.softDelete(deletedAt = beforeCutoff)
+            cardLearningStateRepository.save(deleted)
+
+            val result = cardLearningStateRepository.existsByUserIdAndDeletedAtIsNull(userId = 1L)
+
+            result shouldBe false
+        }
+
+        it("다른 user의 카드는 제외된다") {
+            createCls(cardId = 1L, userId = 2L, status = CardLearningStatus.NEW)
+
+            val result = cardLearningStateRepository.existsByUserIdAndDeletedAtIsNull(userId = 1L)
+
+            result shouldBe false
+        }
+    }
 })

--- a/src/test/kotlin/com/whatever/caro/study/internal/streak/ExistsBasedRestDayCheckServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/streak/ExistsBasedRestDayCheckServiceUnitTest.kt
@@ -1,0 +1,62 @@
+package com.whatever.caro.study.internal.streak
+
+import com.whatever.caro.study.internal.cardlearningstate.CardLearningStateRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+import java.time.ZoneId
+
+class ExistsBasedRestDayCheckServiceUnitTest :
+    DescribeSpec({
+
+        val clsRepository = mockk<CardLearningStateRepository>()
+        val service = ExistsBasedRestDayCheckService(
+            cardLearningStateRepository = clsRepository,
+        )
+
+        afterTest {
+            clearMocks(clsRepository)
+        }
+
+        val userId = 1L
+        val kst = ZoneId.of("Asia/Seoul")
+        val now = Instant.parse("2026-06-20T03:00:00Z")
+
+        describe("isRestDay") {
+            it("오늘 학습할 NEW 카드가 있으면 휴식일이 아니다") {
+                every { clsRepository.existsNewCardByUser(userId) } returns true
+
+                val result = service.isRestDay(now = now, timezone = kst, userId = userId, dayCutoffHour = 0)
+                result shouldBe false
+            }
+
+            it("오늘 복습할 REVIEW 카드가 있으면 휴식일이 아니다") {
+                every { clsRepository.existsNewCardByUser(userId) } returns false
+                every { clsRepository.existsTodayReviewCardByUser(userId, any()) } returns true
+
+                val result = service.isRestDay(now = now, timezone = kst, userId = userId, dayCutoffHour = 0)
+                result shouldBe false
+            }
+
+            it("오늘 학습 대상이 없지만, 카드를 보유하고 있으면 휴식일이다") {
+                every { clsRepository.existsNewCardByUser(userId) } returns false
+                every { clsRepository.existsTodayReviewCardByUser(userId, any()) } returns false
+                every { clsRepository.existsByUserIdAndDeletedAtIsNull(userId) } returns true
+
+                val result = service.isRestDay(now = now, timezone = kst, userId = userId, dayCutoffHour = 0)
+                result shouldBe true
+            }
+
+            it("카드가 전혀 없으면 휴식일이 아니다") {
+                every { clsRepository.existsNewCardByUser(userId) } returns false
+                every { clsRepository.existsTodayReviewCardByUser(userId, any()) } returns false
+                every { clsRepository.existsByUserIdAndDeletedAtIsNull(userId) } returns false
+
+                val result = service.isRestDay(now = now, timezone = kst, userId = userId, dayCutoffHour = 0)
+                result shouldBe false
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
@@ -6,6 +6,9 @@ import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.verify
 import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
@@ -19,6 +22,7 @@ class StreakServiceTest(
     private val streakService: StreakService,
     private val streakStateRepository: StreakStateRepository,
     private val studyDayRepository: StudyDayRepository,
+    private val restDayCheckService: RestDayCheckService,
 ) : DescribeSpec({
 
     val d15 = LocalDate.of(2026, 6, 15)
@@ -34,6 +38,7 @@ class StreakServiceTest(
     ): Instant = date.atTime(hour, 0).atZone(kst).toInstant()
 
     afterTest {
+        clearMocks(restDayCheckService)
         streakStateRepository.deleteAllInBatch()
         studyDayRepository.deleteAllInBatch()
     }
@@ -408,6 +413,56 @@ class StreakServiceTest(
                 dayCutoffHour = 0,
             )
             result2 shouldBe 0 // 클라이언트 날짜는 18일이므로 streak이 끊김
+        }
+    }
+
+    describe("syncWithRestDayCheck") {
+        it("휴식일이고 오늘 기록이 없으면 REST_DAY를 기록하고 streak을 이어준다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            every { restDayCheckService.isRestDay(any(), any(), any(), any()) } returns true
+
+            streakService.syncWithRestDayCheck(
+                userId = USER_ID,
+                now = instantOn(d16),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 2
+            studyDays.first().streakType shouldBe StreakType.REST_DAY
+            studyDays.first().studyDate shouldBe d16
+            streakStateRepository.findByUserId(userId = USER_ID)!!.currentStreak shouldBe 1
+        }
+
+        it("오늘 이미 학습 기록이 있으면 휴식일 판정을 건너뛴다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            streakService.syncWithRestDayCheck(
+                userId = USER_ID,
+                now = instantOn(d16),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+
+            verify(exactly = 0) { restDayCheckService.isRestDay(any(), any(), any(), any()) }
+            studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID) shouldHaveSize 1
+        }
+
+        it("휴식일이 아니면 REST_DAY를 기록하지 않는다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            every { restDayCheckService.isRestDay(any(), any(), any(), any()) } returns false
+
+            streakService.syncWithRestDayCheck(
+                userId = USER_ID,
+                now = instantOn(d16),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 1
+            studyDays.none { it.streakType == StreakType.REST_DAY } shouldBe true
         }
     }
 }) {

--- a/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
@@ -1,0 +1,418 @@
+package com.whatever.caro.study.internal.streak
+
+import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.study.StreakType
+import com.whatever.caro.study.internal.MockDeckPresetApiConfig
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.springframework.context.annotation.Import
+import org.springframework.modulith.test.ApplicationModuleTest
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+class StreakServiceTest(
+    private val streakService: StreakService,
+    private val streakStateRepository: StreakStateRepository,
+    private val studyDayRepository: StudyDayRepository,
+) : DescribeSpec({
+
+    val d15 = LocalDate.of(2026, 6, 15)
+    val d16 = LocalDate.of(2026, 6, 16)
+    val d17 = LocalDate.of(2026, 6, 17)
+    val d18 = LocalDate.of(2026, 6, 18)
+    val d19 = LocalDate.of(2026, 6, 19)
+
+    val kst = ZoneId.of("Asia/Seoul")
+    fun instantOn(
+        date: LocalDate,
+        hour: Int = 12,
+    ): Instant = date.atTime(hour, 0).atZone(kst).toInstant()
+
+    afterTest {
+        streakStateRepository.deleteAllInBatch()
+        studyDayRepository.deleteAllInBatch()
+    }
+
+    describe("recordStudied") {
+        it("최초 학습이면 streak이 1로 생성되고 학습일이 DAILY_STUDY로 기록된다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+            streakState.lastRecordedDate shouldBe d15
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 1
+            studyDays.first().streakType shouldBe StreakType.DAILY_STUDY
+        }
+
+        it("연속 3일을 학습하면 streak이 3이 된다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 3
+            streakState.lastRecordedDate shouldBe d17
+        }
+
+        it("중간에 학습하지 않은 날이 있으면 streak이 끊겨 1이 된다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            // d16 공백
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+            streakState.lastRecordedDate shouldBe d17
+            studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID) shouldHaveSize 2
+        }
+
+        it("streak이 쌓였더라도 한번 끊겼다면 이전 streak이 누적되지 않고 1부터 다시 센다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+            // d18 공백
+            streakService.recordStudied(userId = USER_ID, studyDate = d19)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+            streakState.lastRecordedDate shouldBe d19
+        }
+
+        it("하루에 여러 덱을 학습해도 학습일은 하루로만 계산된다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+            streakService.recordStudied(userId = USER_ID, studyDate = d17) // 다른 덱을 학습해 중복 트리거
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+            streakState.lastRecordedDate shouldBe d17
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 1
+            studyDays.first().streakType shouldBe StreakType.DAILY_STUDY
+        }
+
+        it("같은 날에 학습 기록이 재전송되어도 streak이 중복 증가하지 않는다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16) // 다른 덱을 학습해 중복 트리거
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 2
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 2
+        }
+
+        it("휴식일로 기록되었을 때 학습 기록이 들어온다면 학습일로 수정되고 streak에 반영된다") {
+            streakService.recordRest(userId = USER_ID, restDate = d17)
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 1
+            studyDays.first().streakType shouldBe StreakType.DAILY_STUDY
+        }
+
+        it("한 사용자의 학습 기록은 다른 사용자의 streak에 영향을 주지 않는다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+
+            streakService.recordStudied(userId = OTHER_USER_ID, studyDate = d18)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 3
+
+            val otherStreakState = streakStateRepository.findByUserId(userId = OTHER_USER_ID)!!
+            otherStreakState.currentStreak shouldBe 1
+        }
+    }
+
+    describe("recordRest") {
+        it("휴식일은 streak 카운트에 포함되지 않는다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordRest(userId = USER_ID, restDate = d16)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+            streakState.lastRecordedDate shouldBe d16
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 2
+            studyDays.first().streakType shouldBe StreakType.REST_DAY
+        }
+
+        it("휴식일은 streak을 이어준다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15) // 학습일
+            streakService.recordRest(userId = USER_ID, restDate = d16)
+            streakService.recordStudied(userId = USER_ID, studyDate = d17) // 학습일
+            streakService.recordRest(userId = USER_ID, restDate = d18)
+            streakService.recordRest(userId = USER_ID, restDate = d19)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 2
+            streakState.lastRecordedDate shouldBe d19
+        }
+
+        it("학습일로 기록되었다면 휴식 기록이 들어와도 덮어쓰지 않는다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+            streakService.recordRest(userId = USER_ID, restDate = d17)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 1
+            studyDays.first().streakType shouldBe StreakType.DAILY_STUDY
+        }
+
+        it("같은 날에 휴식일이 중복 전송되어도 상태가 변하지 않는다") {
+            streakService.recordRest(userId = USER_ID, restDate = d17)
+            streakService.recordRest(userId = USER_ID, restDate = d17)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 0
+            streakState.lastRecordedDate shouldBe d17
+
+            val studyDays = studyDayRepository.findAllByUserIdOrderByStudyDateDesc(userId = USER_ID)
+            studyDays shouldHaveSize 1
+            studyDays.first().streakType shouldBe StreakType.REST_DAY
+        }
+
+        it("이미 끊긴 streak은 휴식일로 이어질 수 없다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            // d16 공백
+            streakService.recordRest(userId = USER_ID, restDate = d17) // 휴식일
+            streakService.recordStudied(userId = USER_ID, studyDate = d18)
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 1
+            streakState.lastRecordedDate shouldBe d18
+        }
+    }
+
+    describe("timezone 변경으로 인한 날짜 변경 시 Backfill") {
+        it("학습일을 과거로 Backfill해도 recompute로 streak이 올바르게 합쳐진다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16) // Backfill
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 2
+            streakState.lastRecordedDate shouldBe d17
+        }
+
+        it("Backfill 시 last_recorded_date가 기록의 마지막 날짜로 유지된다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d17)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16) // Backfill
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.lastRecordedDate shouldBe d17
+        }
+    }
+
+    describe("sync") {
+        context("timezone을 수정해 날짜 경계를 넘는 경우") {
+            it("날짜 경계를 동쪽 방향으로 넘어 streak이 끊길 경우 sync하면 current_streak이 0으로 저장된다") {
+                streakService.recordStudied(userId = USER_ID, studyDate = d15)
+                streakService.recordStudied(userId = USER_ID, studyDate = d16) // 마지막 기록일 d16
+
+                // UTC+14에서는 오늘이 d18이라 끊김
+                val now = Instant.parse("2026-06-17T11:00:00Z")
+                streakService.sync(
+                    userId = USER_ID,
+                    now = now,
+                    timezone = ZoneOffset.ofHours(14), // UTC +14
+                    dayCutoffHour = 0,
+                )
+
+                val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+                streakState.currentStreak shouldBe 0
+                streakState.lastRecordedDate shouldBe d16
+            }
+
+            it("날짜 경계를 서쪽 방향으로 넘어 streak이 유효할 경우 sync하면 재계산으로 복구한다") {
+                streakService.recordStudied(userId = USER_ID, studyDate = d15)
+                streakService.recordStudied(userId = USER_ID, studyDate = d16) // 마지막 기록일 d16
+                val now = Instant.parse("2026-06-17T11:00:00Z")
+                streakService.sync( // UTC+14에서는 오늘이 d18이라 streak을 0으로 세팅
+                    userId = USER_ID,
+                    now = now,
+                    timezone = ZoneOffset.ofHours(14),
+                    dayCutoffHour = 0,
+                )
+
+                // UTC-12에서는 오늘이 d16이라 재계산을 통해 복구
+                streakService.sync(
+                    userId = USER_ID,
+                    now = now,
+                    timezone = ZoneOffset.ofHours(-12), // UTC -12
+                    dayCutoffHour = 0,
+                )
+                val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+                streakState.currentStreak shouldBe 2
+                streakState.lastRecordedDate shouldBe d16
+            }
+        }
+
+        it("학습 이력이 없으면 streak_state를 만들지 않는다") {
+            streakService.sync(
+                userId = USER_ID,
+                now = instantOn(d16),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)
+            streakState shouldBe null
+        }
+
+        it("dayCutoffHour를 적용해 클라이언트 로컬 시각의 날짜를 보정한다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            // d18 02:00 + cutoff 4시 = 보정 날짜는 d17
+            streakService.sync(
+                userId = USER_ID,
+                now = instantOn(d18, hour = 2), // 요청이 들어온 시간
+                timezone = kst,
+                dayCutoffHour = 4,
+            )
+
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 2
+            streakState.lastRecordedDate shouldBe d16
+        }
+    }
+
+    describe("getStreak") {
+        it("학습 이력이 없으면 0을 반환한다") {
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d16),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+            result shouldBe 0
+        }
+
+        it("오늘이 마지막 기록일이면 저장된 streak을 반환한다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d16),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+            result shouldBe 2
+        }
+
+        it("마지막 기록일이 어제이면 streak이 깨지지 않았으므로 저장된 streak을 반환한다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d17),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+            result shouldBe 2
+        }
+
+        it("마지막 기록일로부터 이틀 이상 지나면 0을 반환한다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d18),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+            result shouldBe 0
+        }
+
+        it("오늘이 마지막 기록보다 과거여도 streak이 살아있는 것으로 보고 저장된 streak을 반환한다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            // timezone을 서쪽으로 이동하여 날짜 경계를 넘을 경우
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d15),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+            result shouldBe 2
+        }
+
+        it("끊긴 상태를 조회해도 저장된 current_streak을 변경하지 않는다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d18),
+                timezone = kst,
+                dayCutoffHour = 0,
+            )
+
+            result shouldBe 0
+            val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
+            streakState.currentStreak shouldBe 2
+        }
+
+        it("dayCutoffHour를 적용해 경계 시각의 날짜를 보정한다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16)
+
+            // d18 02:00 + cutoff 4시 = 보정 날짜는 d17
+            val result = streakService.getStreak(
+                userId = USER_ID,
+                now = instantOn(d18, hour = 2),
+                timezone = kst,
+                dayCutoffHour = 4,
+            )
+            result shouldBe 2
+        }
+
+        it("같은 시간에 요청을 보내도 timezone에 따라 날짜가 변경된다면 streak 판정이 바뀐다") {
+            streakService.recordStudied(userId = USER_ID, studyDate = d15)
+            streakService.recordStudied(userId = USER_ID, studyDate = d16) // 마지막 기록일 d16
+
+            val now = Instant.parse("2026-06-17T11:00:00Z")
+            // UTC-12 → 오늘 d16
+            val result1 = streakService.getStreak(
+                userId = USER_ID,
+                now = now,
+                timezone = ZoneOffset.ofHours(-12),
+                dayCutoffHour = 0,
+            )
+            result1 shouldBe 2 // 클라이언트는 날짜는 16일이므로 streak이 이어짐
+
+            // UTC+14 → 오늘 d18
+            val result2 = streakService.getStreak(
+                userId = USER_ID,
+                now = now,
+                timezone = ZoneOffset.ofHours(14),
+                dayCutoffHour = 0,
+            )
+            result2 shouldBe 0 // 클라이언트 날짜는 18일이므로 streak이 끊김
+        }
+    }
+}) {
+    companion object {
+        private const val USER_ID = 1L
+        private const val OTHER_USER_ID = 2L
+    }
+}

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
@@ -22,11 +22,12 @@ class StudySessionTest :
             newCardsStudied: Int = 0,
             reviewCardsGoal: Int = 0,
             reviewCardsStudied: Int = 0,
+            status: StudySessionStatus = StudySessionStatus.ACTIVE,
         ): StudySession =
             StudySession(
                 userId = 1L,
                 deckId = 1L,
-                status = StudySessionStatus.ACTIVE,
+                status = status,
                 studyType = StudyType.DAILY,
                 startedAt = Instant.parse("2026-05-18T00:00:00Z"),
                 timezone = kstZoneId,
@@ -156,6 +157,20 @@ class StudySessionTest :
                 s.completeIfGoalAchieved(now)
 
                 s.status shouldBe StudySessionStatus.COMPLETED
+            }
+
+            context("세션 상태에 따라 complete 시 반환값이 달라진다") {
+                withData(
+                    nameFn = { "세션 상태가 $it 라면 ${it == StudySessionStatus.ACTIVE}를 반환한다" },
+                    listOf(StudySessionStatus.ACTIVE, StudySessionStatus.STOPPED, StudySessionStatus.COMPLETED,)
+                ) { status ->
+                    val now = Instant.now()
+                    val s = createSession(status = status)
+
+                    val result = s.completeIfGoalAchieved(now)
+
+                    result shouldBe (status == StudySessionStatus.ACTIVE)
+                }
             }
         }
     })

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionTest.kt
@@ -162,7 +162,7 @@ class StudySessionTest :
             context("세션 상태에 따라 complete 시 반환값이 달라진다") {
                 withData(
                     nameFn = { "세션 상태가 $it 라면 ${it == StudySessionStatus.ACTIVE}를 반환한다" },
-                    listOf(StudySessionStatus.ACTIVE, StudySessionStatus.STOPPED, StudySessionStatus.COMPLETED,)
+                    listOf(StudySessionStatus.ACTIVE, StudySessionStatus.STOPPED, StudySessionStatus.COMPLETED),
                 ) { status ->
                     val now = Instant.now()
                     val s = createSession(status = status)


### PR DESCRIPTION
## 📌 Related Issue
Closes #52 

## 📝 Changes
연속 학습일 기능을 추가했습니다. 며칠 연속 학습 중인지 사용자에게 보여주고, Timezone 변경에도 사용자에게 유리한 쪽으로 판정합니다.
1. streak 도메인
    - 연속 학습일 캐시를 위한 streak_states, 학습일과 휴식일에 대한 로그인 study_days 테이블 추가
    - 학습 진행 시 study_days를 역순으로 읽어 연속 학습일을 재계산
    - `휴식일`은 `연속 학습일`이 끊기지 않게 연결해주지만, 학습일 카운트가 증가하지는 않음(기획에 따라 변경 가능)
2. StreakService
    - `recordStudied`, `recordRest`: 학습일과 휴식일 기록, 휴식일은 학습일로 UPDATE 가능하지만 반대는 불가능
    - `getStreak`: 클라이언트 Timezone의 오늘을 기준으로 streak을 조회
    - `sync`: 클라이언트 Timezone의 오늘을 기준으로 연속 학습일을 동기화
    - `syncWithRestDayCheck`: 휴식일 판정 후 동기화(사용자 진입 시점에 lazy하게 휴식일을 기록)
3. 휴식일 판정
    - EXISTS 쿼리 기반으로 오늘 학습할 카드가 존재하는지 체크
    - 만약 카드 개수가 0개인 유저라면 휴식일로 판정하지 않음
4. 이벤트 연동
    - `EvaluationService`: 일일학습 목표를 달성하여 세션이 완료될 때 `DailyStudyCompletedEvent` publish
    - `StudySession`: entity의 `completeIfGoalAchieved`가 완료 여부를 boolean으로 반환하도록 수정
5. Endpoint 추가
     - `GET /v1/streaks`: 현재 연속 학습일 조회
     - `POST /v1/streaks/sync`: 휴식일 판정 및 연속 학습일 동기화


## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
- Timezone 정책
  - 클라이언트가 전달하는 Timezone을 그대로 사용하며, 이에 따라 Timezone이 급변할 수 있음
    - StreakServiceTest의 `describe("sync")` 테스트 참고
  - 연속 학습일 조회 endpoint는 `streak_states`에 저장된 값을 신뢰하고 반환
  - 시간대 변경 후에는 sync로 동기화해야 `클라이언트 시간대`에서의 정확한 연속 학습일 반환 가능