### PR TITLE
[Fix] path to match 옵션 제거

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -123,6 +123,5 @@ springdoc:
     tags-sorter: alpha
     display-request-duration: true
   packages-to-scan: com.whatever.caro
-  paths-to-match: /api/**, /v1/**
   default-produces-media-type: application/json
   default-consumes-media-type: application/json


### PR DESCRIPTION
## 📌 Related Issue
Closes #53 

## 📝 Changes
v1 endpoint만 swagger에 노출되어 application.yaml에 추가되어있던 spring doc의 path to match 옵션을 제거했습니다.
