### PR TITLE
[Feat] 이메일 암호화 기능 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/common/config/HibernateConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/HibernateConfig.kt
@@ -1,0 +1,20 @@
+package com.whatever.caro.common.config
+
+import org.hibernate.cfg.AvailableSettings
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.jpa.hibernate.SpringBeanContainer
+
+@Configuration
+class HibernateConfig {
+
+    @Bean
+    fun beanContainerCustomizer(
+        beanFactory: ConfigurableListableBeanFactory,
+    ): HibernatePropertiesCustomizer =
+        HibernatePropertiesCustomizer { hibernateProperties ->
+            hibernateProperties[AvailableSettings.BEAN_CONTAINER] = SpringBeanContainer(beanFactory)
+        }
+}

--- a/src/main/kotlin/com/whatever/caro/user/internal/SocialAccount.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/SocialAccount.kt
@@ -31,8 +31,11 @@ class SocialAccount(
     val providerUserId: String,
 
     @Column
-    @Convert(converter = EmailCryptoConverter::class)
     var email: String? = null,
+
+    @Column(name = "encrypted_email", nullable = true)
+    @Convert(converter = EmailCryptoConverter::class)
+    var encryptedEmail: String? = null,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/whatever/caro/user/internal/SocialAccount.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/SocialAccount.kt
@@ -2,7 +2,9 @@ package com.whatever.caro.user.internal
 
 import com.whatever.caro.common.entity.BaseTimeEntity
 import com.whatever.caro.user.SocialProvider
+import com.whatever.caro.user.internal.encrypt.EmailCryptoConverter
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -29,6 +31,7 @@ class SocialAccount(
     val providerUserId: String,
 
     @Column
+    @Convert(converter = EmailCryptoConverter::class)
     var email: String? = null,
 ) : BaseTimeEntity() {
     @Id

--- a/src/main/kotlin/com/whatever/caro/user/internal/SocialAccount.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/SocialAccount.kt
@@ -36,6 +36,9 @@ class SocialAccount(
     @Column(name = "encrypted_email", nullable = true)
     @Convert(converter = EmailCryptoConverter::class)
     var encryptedEmail: String? = null,
+
+    @Column(name = "hashed_email", nullable = true)
+    var hashedEmail: String? = null,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/whatever/caro/user/internal/User.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/User.kt
@@ -2,7 +2,9 @@ package com.whatever.caro.user.internal
 
 import com.whatever.caro.common.entity.SoftDeletableEntity
 import com.whatever.caro.user.UserStatus
+import com.whatever.caro.user.internal.encrypt.EmailCryptoConverter
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -17,6 +19,7 @@ class User(
     @Column(nullable = false)
     var nickname: String,
 
+    @Convert(converter = EmailCryptoConverter::class)
     @Column(name = "primary_email", nullable = true)
     var primaryEmail: String? = null,
 

--- a/src/main/kotlin/com/whatever/caro/user/internal/User.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/User.kt
@@ -19,9 +19,12 @@ class User(
     @Column(nullable = false)
     var nickname: String,
 
-    @Convert(converter = EmailCryptoConverter::class)
     @Column(name = "primary_email", nullable = true)
     var primaryEmail: String? = null,
+
+    @Convert(converter = EmailCryptoConverter::class)
+    @Column(name = "encrypted_primary_email", nullable = true)
+    var encryptedPrimaryEmail: String? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/kotlin/com/whatever/caro/user/internal/User.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/User.kt
@@ -26,6 +26,9 @@ class User(
     @Column(name = "encrypted_primary_email", nullable = true)
     var encryptedPrimaryEmail: String? = null,
 
+    @Column(name = "hashed_primary_email", nullable = true)
+    var hashedPrimaryEmail: String? = null,
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var status: UserStatus = UserStatus.SUSPENDED,

--- a/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
@@ -56,7 +56,7 @@ class UserService(
                 user = user,
                 provider = provider,
                 providerUserId = providerUserId,
-                email = email,
+                encryptedEmail = email,
             )
             socialAccountRepository.save(socialAccount)
 

--- a/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
@@ -68,6 +68,10 @@ class UserService(
 
             return socialAccount.user.toInfo()
         } catch (e: DataIntegrityViolationException) {
+            // NOTE: 이메일 hash UNIQUE(users.active_hashed_primary_email, social_accounts.hashed_email) 추가로
+            //  이 예외가 이제 두 의미를 가짐 - ① 소셜계정(provider+providerUserId) 중복 race ② 동일 이메일 중복.
+            //  현재 복구는 ①만 처리(provider로 재조회). 멀티 provider 같은 이메일 가입(②)은 여기서 못 찾아 re-throw됨.
+            //  TODO: 계정 연동(account linking) 정책 확정 시 제약명으로 원인 구분하여 분기.
             logger.error { "Race condition detected for provider=$provider, providerUserId=$providerUserId" }
             return findBySocialProvider(provider, providerUserId) ?: throw e
         }

--- a/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/UserService.kt
@@ -7,6 +7,7 @@ import com.whatever.caro.user.UserStatus
 import com.whatever.caro.user.exception.AlreadyCompletedException
 import com.whatever.caro.user.exception.NicknameDuplicatedException
 import com.whatever.caro.user.exception.UserNotFoundException
+import com.whatever.caro.user.internal.encrypt.EmailHasher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.repository.findByIdOrNull
@@ -18,6 +19,7 @@ private val logger = KotlinLogging.logger {}
 
 @Service
 class UserService(
+    private val emailHasher: EmailHasher,
     private val userRepository: UserRepository,
     private val socialAccountRepository: SocialAccountRepository,
 ) : UserApi {
@@ -46,9 +48,12 @@ class UserService(
     ): UserInfo {
         try {
             val tempNickname = "temp_${UUID.randomUUID().toString().take(8)}"
+            val hashedSocialEmail = emailHasher.hash(email)
             val user = User(
                 nickname = tempNickname,
                 isTermsAgreed = false,
+                encryptedPrimaryEmail = email,
+                hashedPrimaryEmail = hashedSocialEmail,
             )
             userRepository.save(user)
 
@@ -57,6 +62,7 @@ class UserService(
                 provider = provider,
                 providerUserId = providerUserId,
                 encryptedEmail = email,
+                hashedEmail = hashedSocialEmail,
             )
             socialAccountRepository.save(socialAccount)
 

--- a/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailCryptoConverter.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailCryptoConverter.kt
@@ -1,0 +1,18 @@
+package com.whatever.caro.user.internal.encrypt
+
+import jakarta.persistence.AttributeConverter
+import org.springframework.stereotype.Component
+
+@Component
+class EmailCryptoConverter(
+    private val encryptor: EmailEncryptor,
+) : AttributeConverter<String?, String?> {
+
+    override fun convertToDatabaseColumn(
+        email: String?,
+    ): String? = encryptor.encrypt(email)
+
+    override fun convertToEntityAttribute(
+        encryptedEmail: String?,
+    ): String? = encryptor.decrypt(encryptedEmail)
+}

--- a/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailDecryptionException.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailDecryptionException.kt
@@ -1,0 +1,6 @@
+package com.whatever.caro.user.internal.encrypt
+
+class EmailDecryptionException(
+    message: String,
+    throwable: Throwable,
+) : RuntimeException(message, throwable)

--- a/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailEncryptor.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailEncryptor.kt
@@ -1,0 +1,66 @@
+package com.whatever.caro.user.internal.encrypt
+
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class EmailEncryptor(
+    private val encryptorProperties: EmailEncryptorProperties,
+) {
+    private val keyBytes = Base64.getDecoder().decode(encryptorProperties.encryptionKey)
+    private val key = SecretKeySpec(keyBytes, "AES")
+    private val secureRandom = SecureRandom()
+
+    fun encrypt(
+        email: String?,
+    ): String? {
+        if (email.isNullOrBlank()) return null
+        // 1. iv 생성
+        val iv = ByteArray(IV_LENGTH).also { bytes -> secureRandom.nextBytes(bytes) }
+
+        // 2. email key로 암호화
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
+
+        // 3. Base64(keyVersion + iv + [cipher + tag] -> 이건 doFinal이 만들어줌)
+        val securedEmail = byteArrayOf(KEY_VERSION) + iv + cipher.doFinal(email.toByteArray())
+        val encryptedEmail = Base64.getEncoder().encodeToString(securedEmail)
+        return encryptedEmail
+    }
+
+    fun decrypt(
+        encryptedEmail: String?,
+    ): String? {
+        if (encryptedEmail.isNullOrBlank()) return null
+        // base 64 decode
+        val plainText = runCatching {
+            val decodedRaw = Base64.getDecoder().decode(encryptedEmail)
+            val version = decodedRaw[0] // 당장은 안씀
+
+            // iv 뜯어내고
+            val iv = decodedRaw.copyOfRange(1, 1 + IV_LENGTH)
+
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_LENGTH, iv))
+
+            // cipher text + tag
+            val body = decodedRaw.copyOfRange(1 + IV_LENGTH, decodedRaw.size)
+
+            // decrypt (tag 까지 같이 검증)
+            cipher.doFinal(body)
+        }.getOrElse { throwable ->
+            throw EmailDecryptionException("이메일 복호화 실패", throwable)
+        }
+        return String(plainText, Charsets.UTF_8)
+    }
+
+    companion object {
+        private const val KEY_VERSION: Byte = 1
+        private const val IV_LENGTH = 12
+        private const val TAG_LENGTH = 128
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailEncryptorProperties.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailEncryptorProperties.kt
@@ -1,0 +1,15 @@
+package com.whatever.caro.user.internal.encrypt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.util.Base64
+
+@ConfigurationProperties(prefix = "app.email")
+data class EmailEncryptorProperties(
+    val encryptionKey: String,
+    val blindIndexKey: String,
+) {
+    init {
+        require(encryptionKey.isNotBlank() && !encryptionKey.startsWith($$"${")) { "EMAIL_ENCRYPTION_KEY 미주입" }
+        require(Base64.getDecoder().decode(encryptionKey).size == 32) { "EMAIL_ENCRYPTION_KEY는 Base64 32바이트여야 함" }
+    }
+}

--- a/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailHasher.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/encrypt/EmailHasher.kt
@@ -1,0 +1,30 @@
+package com.whatever.caro.user.internal.encrypt
+
+import org.springframework.stereotype.Component
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class EmailHasher(
+    private val encryptorProperties: EmailEncryptorProperties,
+) {
+    private val keyBytes = Base64.getDecoder().decode(encryptorProperties.blindIndexKey)
+    private val key = SecretKeySpec(keyBytes, ALGORITHM)
+
+    fun hash(
+        email: String?,
+    ): String? {
+        if (email.isNullOrBlank()) return null
+        val lowercaseEmail = email.trim().lowercase()
+        val mac = Mac.getInstance(ALGORITHM)
+        mac.init(key)
+
+        val hash = mac.doFinal(lowercaseEmail.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(hash)
+    }
+
+    companion object {
+        private const val ALGORITHM = "HmacSHA256"
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -24,6 +24,9 @@ app:
       client-ids:
         - local-apple-client-id-1
         - local-apple-client-id-2
+  email:
+    encryption-key: ${EMAIL_ENCRYPTION_KEY}
+    blind-index-key: ${EMAIL_BLIND_INDEX_KEY}
 
 logging:
   level:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -25,8 +25,9 @@ app:
         - local-apple-client-id-1
         - local-apple-client-id-2
   email:
-    encryption-key: ${EMAIL_ENCRYPTION_KEY}
-    blind-index-key: ${EMAIL_BLIND_INDEX_KEY}
+    # 로컬은 Infisical 주입 키 사용. 미주입(테스트 등) 시 더미 키로 폴백 (prod 프로필엔 기본값 두지 말 것)
+    encryption-key: ${EMAIL_ENCRYPTION_KEY:dGVzdC1lbmNyeXB0aW9uLWtleS0wMTIzNDU2Nzg5YWI=}
+    blind-index-key: ${EMAIL_BLIND_INDEX_KEY:dGVzdC1ibGluZGluZGV4LWtleS0wMTIzNDU2Nzg5YWI=}
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,9 @@ app:
     secret: ${JWT_SECRET}
     access-token-expires-in: 30m
     refresh-token-expires-in: 14d
+  email:
+    encryption-key: ${EMAIL_ENCRYPTION_KEY}
+    blind-index-key: ${EMAIL_BLIND_INDEX_KEY}
   idempotency:
     response-ttl: 24h
     processing-ttl: 30s

--- a/src/main/resources/db/migration/user/V2__add_encrypted_email_column.sql
+++ b/src/main/resources/db/migration/user/V2__add_encrypted_email_column.sql
@@ -1,5 +1,5 @@
 ALTER TABLE `users`
-    ADD COLUMN encrypted_primary_email VARCHAR(255) DEFAULT NULL NULL
+    ADD COLUMN encrypted_primary_email VARCHAR(512) NULL;
 
 ALTER TABLE `social_accounts`
-    ADD COLUMN encrypted_email VARCHAR(255) DEFAULT NULL NULL
+    ADD COLUMN encrypted_email VARCHAR(512) NULL;

--- a/src/main/resources/db/migration/user/V2__add_encrypted_email_column.sql
+++ b/src/main/resources/db/migration/user/V2__add_encrypted_email_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `users`
+    ADD COLUMN encrypted_primary_email VARCHAR(255) DEFAULT NULL NULL
+
+ALTER TABLE `social_accounts`
+    ADD COLUMN encrypted_email VARCHAR(255) DEFAULT NULL NULL

--- a/src/main/resources/db/migration/user/V3__add_hashed_email_column.sql
+++ b/src/main/resources/db/migration/user/V3__add_hashed_email_column.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `users`
+    ADD COLUMN hashed_primary_email CHAR(44) NULL
+          COMMENT 'HMAC_SHA256(정규화 email) base64, 길이 44 고정, blind index 검색용',
+    ADD COLUMN active_hashed_primary_email CHAR(44)
+        AS (IF(deleted_at IS NULL, hashed_primary_email, NULL)) VIRTUAL,
+    ADD CONSTRAINT uk_users_active_hashed_primary_email UNIQUE (active_hashed_primary_email);
+
+
+ALTER TABLE `social_accounts`
+    ADD COLUMN hashed_email CHAR(44) NULL
+          COMMENT 'HMAC_SHA256(정규화 email) base64, 길이 44 고정, blind index 검색용',
+    ADD CONSTRAINT uk_social_accounts_hashed_email UNIQUE (hashed_email);

--- a/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
@@ -15,6 +15,8 @@ import com.whatever.caro.auth.internal.web.request.SocialLoginRequest
 import com.whatever.caro.user.SocialProvider
 import com.whatever.caro.user.UserApi
 import com.whatever.caro.user.UserStatus
+import com.whatever.caro.user.internal.SocialAccountRepository
+import com.whatever.caro.user.internal.UserRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -54,6 +56,8 @@ class AuthServiceTest(
     private val jwtTokenProvider: JwtTokenProvider,
     private val redisTemplate: StringRedisTemplate,
     private val userApi: UserApi,
+    private val userRepository: UserRepository,
+    private val socialAccountRepository: SocialAccountRepository,
 ) : DescribeSpec({
 
     val mockVerifier = mockk<SocialIdTokenVerifier>()
@@ -61,6 +65,9 @@ class AuthServiceTest(
     afterEach {
         clearMocks(socialIdTokenVerifierFactory, mockVerifier, answers = false)
         redisTemplate.connectionFactory?.connection?.serverCommands()?.flushDb()
+        // 테스트 격리: 이메일 UNIQUE 충돌 방지를 위해 매 테스트 후 user/social 데이터 정리 (FK 때문에 social 먼저)
+        socialAccountRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
     }
 
     fun stubSocialVerifier(

--- a/src/test/kotlin/com/whatever/caro/auth/internal/config/SwaggerStagingBasicAuthTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/config/SwaggerStagingBasicAuthTest.kt
@@ -37,6 +37,8 @@ private fun basicAuthHeader(
         "REDIS_PASSWORD=dummy",
         "SWAGGER_USERNAME=test-user",
         "SWAGGER_PASSWORD=test-pass",
+        "EMAIL_ENCRYPTION_KEY=dGVzdC1lbmNyeXB0aW9uLWtleS0wMTIzNDU2Nzg5YWI=",
+        "EMAIL_BLIND_INDEX_KEY=dGVzdC1ibGluZGluZGV4LWtleS0wMTIzNDU2Nzg5YWI=",
         "management.server.port=8080",
     ],
 )

--- a/src/test/kotlin/com/whatever/caro/common/config/SwaggerDisabledInProdTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/config/SwaggerDisabledInProdTest.kt
@@ -27,6 +27,8 @@ import org.springframework.test.web.servlet.get
         "DB_PASSWORD=dummy",
         "REDIS_HOST=dummy",
         "REDIS_PASSWORD=dummy",
+        "EMAIL_ENCRYPTION_KEY=dGVzdC1lbmNyeXB0aW9uLWtleS0wMTIzNDU2Nzg5YWI=",
+        "EMAIL_BLIND_INDEX_KEY=dGVzdC1ibGluZGluZGV4LWtleS0wMTIzNDU2Nzg5YWI=",
     ],
 )
 class SwaggerDisabledInProdTest(

--- a/src/test/kotlin/com/whatever/caro/user/internal/UserServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/user/internal/UserServiceTest.kt
@@ -46,7 +46,7 @@ class UserServiceTest(
         provider: SocialProvider,
         providerUserId: String,
         email: String? = null,
-    ): SocialAccount = socialAccountRepository.save(SocialAccount(user = user, provider = provider, providerUserId = providerUserId, email = email))
+    ): SocialAccount = socialAccountRepository.save(SocialAccount(user = user, provider = provider, providerUserId = providerUserId, encryptedEmail = email))
 
     describe("createSocialUser") {
         data class EmailCase(

--- a/src/test/kotlin/com/whatever/caro/user/internal/UserServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/user/internal/UserServiceUnitTest.kt
@@ -2,6 +2,7 @@ package com.whatever.caro.user.internal
 
 import com.whatever.caro.user.SocialProvider
 import com.whatever.caro.user.UserApi
+import com.whatever.caro.user.internal.encrypt.EmailHasher
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -12,9 +13,10 @@ import org.springframework.dao.DataIntegrityViolationException
 class UserServiceUnitTest :
     DescribeSpec({
 
+        val mockEmailHasher = mockk<EmailHasher>(relaxed = true)
         val mockUserRepo = mockk<UserRepository>(relaxed = true)
         val mockSocialRepo = mockk<SocialAccountRepository>(relaxed = true)
-        val userApi: UserApi = UserService(userRepository = mockUserRepo, socialAccountRepository = mockSocialRepo)
+        val userApi: UserApi = UserService(emailHasher = mockEmailHasher, userRepository = mockUserRepo, socialAccountRepository = mockSocialRepo)
 
         fun createUserWithId(
             id: Long,

--- a/src/test/kotlin/com/whatever/caro/user/internal/encrypt/EmailEncryptorTest.kt
+++ b/src/test/kotlin/com/whatever/caro/user/internal/encrypt/EmailEncryptorTest.kt
@@ -1,0 +1,68 @@
+package com.whatever.caro.user.internal.encrypt
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.util.Base64
+
+class EmailEncryptorTest :
+    DescribeSpec({
+
+        // 32바이트 ASCII의 base64 (테스트 전용 더미 키)
+        val properties = EmailEncryptorProperties(
+            encryptionKey = "dGVzdC1lbmNyeXB0aW9uLWtleS0wMTIzNDU2Nzg5YWI=",
+            blindIndexKey = "dGVzdC1ibGluZGluZGV4LWtleS0wMTIzNDU2Nzg5YWI=",
+        )
+        val encryptor = EmailEncryptor(properties)
+
+        describe("encrypt / decrypt") {
+            it("암호화 후 복호화하면 원본 이메일이 나온다 (왕복)") {
+                val email = "foo@example.com"
+
+                val encrypted = encryptor.encrypt(email)
+                val decrypted = encryptor.decrypt(encrypted)
+
+                decrypted shouldBe email
+            }
+
+            it("같은 이메일이라도 암호화할 때마다 다른 암호문이 된다 (IV 랜덤)") {
+                val email = "foo@example.com"
+
+                val first = encryptor.encrypt(email)
+                val second = encryptor.encrypt(email)
+
+                first shouldNotBe second
+                // 비결정적이어도 둘 다 같은 평문으로 복호화돼야 한다
+                encryptor.decrypt(first) shouldBe email
+                encryptor.decrypt(second) shouldBe email
+            }
+
+            it("null / blank 는 null 을 반환한다") {
+                encryptor.encrypt(null) shouldBe null
+                encryptor.encrypt("") shouldBe null
+                encryptor.encrypt("  ") shouldBe null
+                encryptor.decrypt(null) shouldBe null
+                encryptor.decrypt("") shouldBe null
+            }
+
+            it("변조된 암호문은 EmailDecryptionException 을 던진다 (tag 검증 실패)") {
+                val encrypted = encryptor.encrypt("foo@example.com")!!
+
+                // 마지막 바이트(tag 일부)를 1비트 뒤집어 변조
+                val raw = Base64.getDecoder().decode(encrypted)
+                raw[raw.size - 1] = (raw[raw.size - 1].toInt() xor 0x01).toByte()
+                val tampered = Base64.getEncoder().encodeToString(raw)
+
+                shouldThrow<EmailDecryptionException> {
+                    encryptor.decrypt(tampered)
+                }
+            }
+
+            it("base64 가 아닌 손상된 값도 EmailDecryptionException 으로 감싼다") {
+                shouldThrow<EmailDecryptionException> {
+                    encryptor.decrypt("not_a_valid_base64!!!")
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/user/internal/encrypt/EmailHasherTest.kt
+++ b/src/test/kotlin/com/whatever/caro/user/internal/encrypt/EmailHasherTest.kt
@@ -1,0 +1,42 @@
+package com.whatever.caro.user.internal.encrypt
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class EmailHasherTest :
+    DescribeSpec({
+
+        val properties = EmailEncryptorProperties(
+            encryptionKey = "dGVzdC1lbmNyeXB0aW9uLWtleS0wMTIzNDU2Nzg5YWI=",
+            blindIndexKey = "dGVzdC1ibGluZGluZGV4LWtleS0wMTIzNDU2Nzg5YWI=",
+        )
+        val hasher = EmailHasher(properties)
+
+        describe("hash") {
+            it("같은 이메일은 항상 같은 해시를 만든다 (결정적)") {
+                hasher.hash("foo@example.com") shouldBe hasher.hash("foo@example.com")
+            }
+
+            it("대소문자/앞뒤 공백을 정규화해 같은 해시를 만든다") {
+                val normalized = hasher.hash("foo@example.com")
+
+                hasher.hash("  Foo@Example.COM  ") shouldBe normalized
+                hasher.hash("FOO@EXAMPLE.COM") shouldBe normalized
+            }
+
+            it("다른 이메일은 다른 해시를 만든다") {
+                hasher.hash("alice@example.com") shouldNotBe hasher.hash("bob@example.com")
+            }
+
+            it("null / blank 는 null 을 반환한다") {
+                hasher.hash(null) shouldBe null
+                hasher.hash("") shouldBe null
+                hasher.hash("   ") shouldBe null
+            }
+
+            it("해시는 base64 44자 고정이다 (HMAC-SHA256 32바이트)") {
+                hasher.hash("foo@example.com")!!.length shouldBe 44
+            }
+        }
+    })


### PR DESCRIPTION
## 📌 Related Issue
Closes #44

## 📝 Changes
이메일 암호화 기능 추가했습니다

이거 머지 이후에
1. 기존에 DB에 저장된 이메일 암호화된 필드 채우는 배치나 로직을 한번은 수행해야합니다
2. 이후에 평문 이메일 제거 + 유니크인 VIRUTAL 제거 + 암호화된 필드 Not Null 타입으로 변경 필요
3. 검색시에는 해싱된 이메일에 검색, 평문이 필요할땐 encryptedPrimaryEmail 를 사용합니당

요고 실제 postman으로 테스트를 못해봤는데, 소셜 로그인을 실제 테스트해보려면,, ,어케해요 ? @given-dragon 답을 알려주세요 ㅠ

++ 추가로 1번은 배치로 딸깍할 수 있게 만들어볼게용

## ✅ Checklist
- [ ] 테스트 완료
- [ ] 리뷰 준비 완료

## 📋 Additional Notes(Optional)