### PR TITLE
[Feat] 카드 대량 삭제 기능 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -7,6 +7,7 @@ import com.whatever.caro.card.internal.card.dto.create.toDto
 import com.whatever.caro.card.internal.card.dto.create.toResponse
 import com.whatever.caro.card.internal.card.dto.delete.DeleteCardDto
 import com.whatever.caro.card.internal.card.dto.delete.DeleteCardResponse
+import com.whatever.caro.card.internal.card.dto.delete.DeleteCardsRequest
 import com.whatever.caro.card.internal.card.dto.delete.toResponse
 import com.whatever.caro.card.internal.card.dto.read.CardResponse
 import com.whatever.caro.card.internal.card.dto.read.toResponse
@@ -76,13 +77,12 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
-    @DeleteMapping("/v1/cards/{id}")
-    fun deleteCard(
-        @Parameter(description = "카드 ID", required = true)
-        @Positive @PathVariable id: Long,
+    @DeleteMapping("/v1/cards")
+    fun deleteCards(
+        @RequestBody @Valid cards: DeleteCardsRequest,
     ): ResponseEntity<ApiResponse<DeleteCardResponse>> {
         val userId = SecurityUtil.currentUser().userId
-        val result = cardService.deleteCard(userId = userId, dto = DeleteCardDto(cardId = id)).toResponse()
+        val result = cardService.deleteCard(userId = userId, dto = DeleteCardDto(cardIds = cards.cardIds)).toResponse()
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 }

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardOwnership.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardOwnership.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro.card.internal.card
+
+import java.time.Instant
+
+data class CardOwnership(
+    val id: Long,
+    val userId: Long,
+    val deletedAt: Instant?,
+)

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardRepository.kt
@@ -51,7 +51,7 @@ interface CardRepository : JpaRepository<Card, Long> {
             where c.note.id in :referencedNoteIds
             and c.deletedAt IS NULL
             and c.id not in :deletingCardIds
-        """
+        """,
     )
     fun findSurvivorNoteIdsByNoteIdInExcludingCards(
         referencedNoteIds: Collection<Long>,
@@ -63,7 +63,7 @@ interface CardRepository : JpaRepository<Card, Long> {
             select new com.whatever.caro.card.internal.card.CardOwnership(c.id, c.userId, c.deletedAt)
             from Card c
             where c.id in :ids
-        """
+        """,
     )
     fun findAllByIds(
         ids: Collection<Long>,

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardRepository.kt
@@ -44,4 +44,15 @@ interface CardRepository : JpaRepository<Card, Long> {
         noteId: Long,
         id: Long,
     ): Long
+
+    @Query(
+        """
+            select new com.whatever.caro.card.internal.card.CardOwnership(c.id, c.userId, c.deletedAt)
+            from Card c
+            where c.id in :ids
+        """
+    )
+    fun findAllByIds(
+        ids: Collection<Long>,
+    ): List<CardOwnership>
 }

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardRepository.kt
@@ -47,6 +47,19 @@ interface CardRepository : JpaRepository<Card, Long> {
 
     @Query(
         """
+            select distinct c.note.id from Card c
+            where c.note.id in :referencedNoteIds
+            and c.deletedAt IS NULL
+            and c.id not in :deletingCardIds
+        """
+    )
+    fun findSurvivorNoteIdsByNoteIdInExcludingCards(
+        referencedNoteIds: Collection<Long>,
+        deletingCardIds: Collection<Long>,
+    ): List<Long>
+
+    @Query(
+        """
             select new com.whatever.caro.card.internal.card.CardOwnership(c.id, c.userId, c.deletedAt)
             from Card c
             where c.id in :ids

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -204,32 +204,48 @@ class CardService(
         userId: Long,
         dto: DeleteCardDto,
     ): DeleteCardResponseDto {
-        val card = cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(dto.cardId)
-            ?: throw CardNotFoundException("cardId=${dto.cardId} 카드를 찾을 수 없습니다")
+        // 받은 카드들 중에서 내게 아닌 카드가 섞여있는지 체크. 한개라도 있다면 카드 삭제 수행 하지 않음
+        val cards = cardRepository.findAllByIds(dto.cardIds)
+        val anotherUserCard = cards.find { it.userId != userId }
+        if (anotherUserCard != null) throw CardForbiddenException("cardId=${anotherUserCard.id} 에 대한 접근 권한이 없습니다")
 
-        if (card.userId != userId) {
-            throw CardForbiddenException("cardId=${dto.cardId} 에 대한 접근 권한이 없습니다")
-        }
+        val (aliveCards, alreadyDeletedCards) = cards.partition { it.deletedAt == null }
+
+        // 삭제 되지 않은 카드들에 대해서만 조회해서 삭제처리
+        // 0 개라면 이벤트, 삭제처리 없이 그대로 종료
+        val deletedCards = aliveCards
+            .map { aliveCard -> aliveCard.id }
+            .takeIf { it.isNotEmpty() }
+            ?.let { cards ->
+                cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(
+                    ids = cards,
+                    userId = userId,
+                )
+            }
+            ?: return DeleteCardResponseDto(deletedCardsCount = 0)
 
         val now = Instant.now(clock)
-        card.softDelete(deletedAt = now)
-        card.deck.cardCount = maxOf(0, card.deck.cardCount - 1)
-
-        if (cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(card.note.id, card.id) == 0L) {
-            card.note.softDelete(deletedAt = now)
+        // 삭제 및 연관관계인 덱쪽의 카드카운트를 1개 빼주고, 노트 또한 삭제
+        deletedCards.forEach { card ->
+            card.softDelete(now)
+            card.deck.cardCount = maxOf(0, card.deck.cardCount - 1)
+            if (cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(card.note.id, card.id) == 0L) {
+                card.note.softDelete(deletedAt = now)
+            }
         }
-// TODO 배치삭제로 수정 필요
+
+        // TODO 배치삭제로 수정 필요
         eventPublisher.publishEvent(
             CardsDeletedEvent(
-                deckId = card.deck.id,
-                deletedCount = 1,
+                deckId = deletedCards.first().deck.id,
+                deletedCount = deletedCards.count(),
                 userId = userId,
-                deletedCardIds = setOf(card.id),
+                deletedCardIds = deletedCards.map { it.id }.toSet(),
                 deletedAt = now,
             ),
         )
 
-        return DeleteCardResponseDto(cardId = card.id)
+        return DeleteCardResponseDto(deletedCardsCount = aliveCards.count())
     }
 
     private fun projectFields(

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -113,7 +113,10 @@ class CardService(
             )
         }
 
-        deck.cardCount += createdCards.size
+        deckRepository.increaseCardCount(
+            deckId = deck.id,
+            amount = createdCards.size,
+        )
         eventPublisher.publishEvent(
             CardsCreatedEvent(cardIds = createdCards.map { it.cardId }, deckId = deck.id, userId = userId),
         )

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -222,7 +222,7 @@ class CardService(
                     userId = userId,
                 )
             }
-            ?: return DeleteCardResponseDto(deletedCardsCount = 0)
+            ?: return DeleteCardResponseDto(deletedCardsCount = cards.size)
 
         val referencedNoteIds = deletedCards.map { it.note.id }.toSet()
         val survivorNoteIds = cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -208,45 +208,46 @@ class CardService(
     ): DeleteCardResponseDto {
         // 받은 카드들 중에서 내게 아닌 카드가 섞여있는지 체크. 한개라도 있다면 카드 삭제 수행 하지 않음
         val cards = cardRepository.findAllByIds(dto.cardIds)
-        val anotherUserCard = cards.find { it.userId != userId }
-        if (anotherUserCard != null) throw CardForbiddenException("cardId=${anotherUserCard.id} 에 대한 접근 권한이 없습니다")
-
         val (aliveCards, _) = cards.partition { it.deletedAt == null }
 
-        // 삭제 되지 않은 카드들에 대해서만 조회해서 삭제처리
-        // 0 개라면 이벤트, 삭제처리 없이 그대로 종료
-        val deletedCards = aliveCards
-            .map { aliveCard -> aliveCard.id }
-            .takeIf { it.isNotEmpty() }
-            ?.let { cards ->
-                cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(
-                    ids = cards,
-                    userId = userId,
-                )
-            }
-            ?: return DeleteCardResponseDto(deletedCardsCount = cards.size)
+        val anotherUserCard = aliveCards.find { it.userId != userId }
+        if (anotherUserCard != null) {
+            throw CardForbiddenException("cardId=${anotherUserCard.id} 에 대한 접근 권한이 없습니다")
+        }
 
-        val referencedNoteIds = deletedCards.map { it.note.id }.toSet()
+        // 응답 count 는 요청 중 "내 카드"만 센다 (남의 삭제된 카드는 존재 여부 노출 방지 위해 제외)
+        val myCards = cards.filter { it.userId == userId }
+
+        // 삭제 대상(살아있는 내 카드) — 없으면 삭제/이벤트 없이 count 만 반환
+        val aliveCardIds = aliveCards.map { it.id }
+        if (aliveCardIds.isEmpty()) {
+            return DeleteCardResponseDto(deletedCardsCount = myCards.size)
+        }
+
+        val cardsToDelete = cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(
+            ids = aliveCardIds,
+            userId = userId,
+        )
+
+        val referencedNoteIds = cardsToDelete.map { it.note.id }.toSet()
         val survivorNoteIds = cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(
             referencedNoteIds = referencedNoteIds,
-            deletingCardIds = deletedCards.map { it.id },
+            deletingCardIds = cardsToDelete.map { it.id },
         ).toSet()
         val orphanNoteIds = referencedNoteIds - survivorNoteIds
 
         val now = Instant.now(clock)
-        // 삭제 및 연관관계인 덱쪽의 카드카운트를 1개 빼줌
-        deletedCards.forEach { card ->
-            card.softDelete(now)
-            card.deck.cardCount = maxOf(0, card.deck.cardCount - 1)
-        }
+        // 카드 soft delete (덱 카드 수 감소는 아래 덱별 처리에서 수행)
+        cardsToDelete.forEach { card -> card.softDelete(now) }
         // 노트가 더이상 참조하는 카드가 없다면 노트도 삭제
-        deletedCards.filter { it.note.id in orphanNoteIds }
+        cardsToDelete.filter { it.note.id in orphanNoteIds }
             .forEach { card -> card.note.softDelete(now) }
 
         // TODO 배치삭제로 수정 필요
         // 덱 별로 삭제 이벤트 발행
-        deletedCards.groupBy { it.deck.id }
+        cardsToDelete.groupBy { it.deck.id }
             .forEach { (deckId, deckCards) ->
+                deckRepository.decreaseCardCount(deckId, deckCards.size)
                 eventPublisher.publishEvent(
                     CardsDeletedEvent(
                         deckId = deckId,
@@ -259,7 +260,7 @@ class CardService(
                 )
             }
 
-        return DeleteCardResponseDto(deletedCardsCount = cards.size)
+        return DeleteCardResponseDto(deletedCardsCount = myCards.size)
     }
 
     private fun projectFields(

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -209,7 +209,7 @@ class CardService(
         val anotherUserCard = cards.find { it.userId != userId }
         if (anotherUserCard != null) throw CardForbiddenException("cardId=${anotherUserCard.id} 에 대한 접근 권한이 없습니다")
 
-        val (aliveCards, alreadyDeletedCards) = cards.partition { it.deletedAt == null }
+        val (aliveCards, _) = cards.partition { it.deletedAt == null }
 
         // 삭제 되지 않은 카드들에 대해서만 조회해서 삭제처리
         // 0 개라면 이벤트, 삭제처리 없이 그대로 종료
@@ -235,17 +235,21 @@ class CardService(
         }
 
         // TODO 배치삭제로 수정 필요
-        eventPublisher.publishEvent(
-            CardsDeletedEvent(
-                deckId = deletedCards.first().deck.id,
-                deletedCount = deletedCards.count(),
-                userId = userId,
-                deletedCardIds = deletedCards.map { it.id }.toSet(),
-                deletedAt = now,
-            ),
-        )
+        // 덱 별로 삭제 이벤트 발행
+        deletedCards.groupBy { it.deck.id }
+            .forEach { (deckId, deckCards) ->
+                eventPublisher.publishEvent(
+                    CardsDeletedEvent(
+                        deckId = deckId,
+                        deletedCount = deckCards.size,
+                        userId = userId,
+                        deletedCardIds = deckCards.map { it.id }.toSet(),
+                        deletedAt = now,
+                    ),
+                )
+            }
 
-        return DeleteCardResponseDto(deletedCardsCount = aliveCards.count())
+        return DeleteCardResponseDto(deletedCardsCount = cards.size)
     }
 
     private fun projectFields(

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardService.kt
@@ -224,15 +224,22 @@ class CardService(
             }
             ?: return DeleteCardResponseDto(deletedCardsCount = 0)
 
+        val referencedNoteIds = deletedCards.map { it.note.id }.toSet()
+        val survivorNoteIds = cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(
+            referencedNoteIds = referencedNoteIds,
+            deletingCardIds = deletedCards.map { it.id },
+        ).toSet()
+        val orphanNoteIds = referencedNoteIds - survivorNoteIds
+
         val now = Instant.now(clock)
-        // 삭제 및 연관관계인 덱쪽의 카드카운트를 1개 빼주고, 노트 또한 삭제
+        // 삭제 및 연관관계인 덱쪽의 카드카운트를 1개 빼줌
         deletedCards.forEach { card ->
             card.softDelete(now)
             card.deck.cardCount = maxOf(0, card.deck.cardCount - 1)
-            if (cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(card.note.id, card.id) == 0L) {
-                card.note.softDelete(deletedAt = now)
-            }
         }
+        // 노트가 더이상 참조하는 카드가 없다면 노트도 삭제
+        deletedCards.filter { it.note.id in orphanNoteIds }
+            .forEach { card -> card.note.softDelete(now) }
 
         // TODO 배치삭제로 수정 필요
         // 덱 별로 삭제 이벤트 발행

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardDto.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardDto.kt
@@ -1,5 +1,5 @@
 package com.whatever.caro.card.internal.card.dto.delete
 
 data class DeleteCardDto(
-    val cardId: Long,
+    val cardIds: Set<Long>,
 )

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardResponse.kt
@@ -1,5 +1,5 @@
 package com.whatever.caro.card.internal.card.dto.delete
 
 data class DeleteCardResponse(
-    val cardId: Long,
+    val deletedCardsCount: Int,
 )

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardResponseDto.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardResponseDto.kt
@@ -1,10 +1,7 @@
 package com.whatever.caro.card.internal.card.dto.delete
 
 data class DeleteCardResponseDto(
-    val cardId: Long,
+    val deletedCardsCount: Int,
 )
 
-fun DeleteCardResponseDto.toResponse() =
-    DeleteCardResponse(
-        cardId = cardId,
-    )
+fun DeleteCardResponseDto.toResponse() = DeleteCardResponse(deletedCardsCount = deletedCardsCount)

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardsRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardsRequest.kt
@@ -1,0 +1,13 @@
+package com.whatever.caro.card.internal.card.dto.delete
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+
+data class DeleteCardsRequest(
+    @field:NotEmpty
+    @field:Size(max = 1000)
+    @Schema(description = "카드 ID 들 (최소 1개 - 최대 1000개)", required = true)
+    val cardIds: Set<@Positive Long>,
+)

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardsRequest.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/dto/delete/DeleteCardsRequest.kt
@@ -1,13 +1,18 @@
 package com.whatever.caro.card.internal.card.dto.delete
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
 
 data class DeleteCardsRequest(
     @field:NotEmpty
     @field:Size(max = 1000)
     @Schema(description = "카드 ID 들 (최소 1개 - 최대 1000개)", required = true)
-    val cardIds: Set<@Positive Long>,
-)
+    val cardIds: Set<Long>,
+) {
+    @get:AssertTrue(message = "cardIds는 모두 양수여야 합니다")
+    @get:Schema(hidden = true)
+    val isAllPositive: Boolean
+        get() = cardIds.all { it > 0 }
+}

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
@@ -1,6 +1,7 @@
 package com.whatever.caro.card.internal.deck
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
@@ -38,4 +39,11 @@ interface DeckRepository : JpaRepository<Deck, Long> {
     fun findByIdWithPreset(
         deckId: Long,
     ): Deck?
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Deck d set d.cardCount = d.cardCount - :amount where d.id = :deckId")
+    fun decreaseCardCount(
+        deckId: Long,
+        amount: Int,
+    ): Int
 }

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/DeckRepository.kt
@@ -46,4 +46,11 @@ interface DeckRepository : JpaRepository<Deck, Long> {
         deckId: Long,
         amount: Int,
     ): Int
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Deck d set d.cardCount = d.cardCount + :amount where d.id = :deckId")
+    fun increaseCardCount(
+        deckId: Long,
+        amount: Int,
+    ): Int
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,8 @@ spring:
         format_sql: true
         auto_quote_keyword: true
         order_updates: true
+        jdbc:
+          batch_size: 100
     hibernate:
       ddl-auto: none
     database-platform: org.hibernate.dialect.MySQLDialect

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerUnitTest.kt
@@ -9,6 +9,7 @@ import com.whatever.caro.card.internal.card.dto.create.CreateCardsRequest
 import com.whatever.caro.card.internal.card.dto.create.CreateCardsResponseDto
 import com.whatever.caro.card.internal.card.dto.delete.DeleteCardDto
 import com.whatever.caro.card.internal.card.dto.delete.DeleteCardResponseDto
+import com.whatever.caro.card.internal.card.dto.delete.DeleteCardsRequest
 import com.whatever.caro.card.internal.card.dto.read.CardResponseDto
 import com.whatever.caro.card.internal.card.dto.update.UpdateCardDto
 import com.whatever.caro.card.internal.card.dto.update.UpdateCardRequest
@@ -132,18 +133,18 @@ class CardControllerUnitTest :
             }
         }
 
-        describe("deleteCard") {
-            it("DeleteCardDto 로 서비스에 위임하고 200 과 삭제된 카드 id 를 반환한다") {
-                every { cardService.deleteCard(1L, DeleteCardDto(cardId = 100L)) } returns DeleteCardResponseDto(
-                    cardId = 100L,
+        describe("deleteCards") {
+            it("DeleteCardsRequest 를 DeleteCardDto 로 변환해 서비스에 위임하고 200 과 삭제 개수를 반환한다") {
+                every { cardService.deleteCard(1L, DeleteCardDto(cardIds = setOf(100L, 101L))) } returns DeleteCardResponseDto(
+                    deletedCardsCount = 2,
                 )
 
-                val response = controller.deleteCards(100L)
+                val response = controller.deleteCards(DeleteCardsRequest(cardIds = setOf(100L, 101L)))
 
                 response.statusCode shouldBe HttpStatus.OK
                 response.body!!.success shouldBe true
-                response.body!!.data!!.cardId shouldBe 100L
-                verify { cardService.deleteCard(1L, DeleteCardDto(cardId = 100L)) }
+                response.body!!.data!!.deletedCardsCount shouldBe 2
+                verify { cardService.deleteCard(1L, DeleteCardDto(cardIds = setOf(100L, 101L))) }
             }
         }
     })

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerUnitTest.kt
@@ -138,7 +138,7 @@ class CardControllerUnitTest :
                     cardId = 100L,
                 )
 
-                val response = controller.deleteCard(100L)
+                val response = controller.deleteCards(100L)
 
                 response.statusCode shouldBe HttpStatus.OK
                 response.body!!.success shouldBe true

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerUnitTest.kt
@@ -19,10 +19,10 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.ZoneId
 import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
+import java.time.ZoneId
 
 class CardControllerUnitTest :
     DescribeSpec({

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerWebMvcTest.kt
@@ -18,6 +18,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
@@ -92,6 +93,36 @@ class CardControllerWebMvcTest : DescribeSpec() {
                 mockMvc.patch("/v1/cards/1") {
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"fields": {}}"""
+                }.andExpect {
+                    status { isBadRequest() }
+                }
+            }
+        }
+
+        describe("DELETE /v1/cards - @Valid 검증") {
+            it("cardIds 가 비어있으면 400 을 반환한다") {
+                mockMvc.delete("/v1/cards") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"cardIds": []}"""
+                }.andExpect {
+                    status { isBadRequest() }
+                }
+            }
+
+            it("cardIds 가 1000개를 초과하면 400 을 반환한다") {
+                val ids = (1..1001).joinToString(",")
+                mockMvc.delete("/v1/cards") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"cardIds": [$ids]}"""
+                }.andExpect {
+                    status { isBadRequest() }
+                }
+            }
+
+            it("cardIds 에 0 이하가 섞이면 400 을 반환한다") {
+                mockMvc.delete("/v1/cards") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"cardIds": [1, 0]}"""
                 }.andExpect {
                     status { isBadRequest() }
                 }

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
@@ -479,25 +479,146 @@ class CardServiceUnitTest :
         }
 
         describe("deleteCard") {
-            it("같은 노트의 다른 카드가 남아있으면 카드만 soft delete 하고 cardCount 를 1 감소시킨다") {
+            it("여러 카드를 soft delete 하고, 마지막 카드인 노트는 함께 삭제하며, 덱 cardCount 를 감소시킨다") {
                 val userId = 1L
                 val noteType = newNoteType(id = 1L)
                 val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
-                val note = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
-                val deck = newDeck(id = 10L, userId = userId, cardCount = 3)
-                val card = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
+                val deck = newDeck(id = 10L, userId = userId, cardCount = 5)
+                val note1 = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
+                val note2 = newNote(id = 201L, userId = userId, fields = mapOf("front" to "b"))
+                val card1 = newCard(id = 300L, template = tpl, note = note1, deck = deck, userId = userId)
+                val card2 = newCard(id = 301L, template = tpl, note = note2, deck = deck, userId = userId)
 
-                every { cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(300L) } returns card
-                every { cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(200L, 300L) } returns 1L
-
-                val result = cardService.deleteCard(
-                    userId = userId,
-                    dto = DeleteCardDto(cardId = 300L),
+                every { cardRepository.findAllByIds(setOf(300L, 301L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                    CardOwnership(id = 301L, userId = userId, deletedAt = null),
                 )
+                every {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L, 301L), userId)
+                } returns listOf(card1, card2)
+                // 두 노트 모두 이번에 지우는 카드 외에 남는 산 카드가 없음 → survivor 없음 → 둘 다 고아
+                every {
+                    cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L, 201L), listOf(300L, 301L))
+                } returns emptyList()
 
-                result.cardId shouldBe 300L
+                val result = cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L, 301L)))
+
+                result.deletedCardsCount shouldBe 2
+                card1.isDeleted.shouldBeTrue()
+                card2.isDeleted.shouldBeTrue()
+                note1.isDeleted.shouldBeTrue()
+                note2.isDeleted.shouldBeTrue()
+                deck.cardCount shouldBe 3
+                verify {
+                    eventPublisher.publishEvent(
+                        CardsDeletedEvent(
+                            deckId = 10L,
+                            deletedCount = 2,
+                            userId = userId,
+                            deletedCardIds = setOf(300L, 301L),
+                            deletedAt = fixedNow,
+                        ),
+                    )
+                }
+            }
+
+            it("같은 노트를 공유하는 다른 산 카드가 남으면 그 노트는 삭제하지 않는다") {
+                val userId = 1L
+                val noteType = newNoteType(id = 1L)
+                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
+                val deck = newDeck(id = 10L, userId = userId, cardCount = 3)
+                val sharedNote = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
+                val card = newCard(id = 300L, template = tpl, note = sharedNote, deck = deck, userId = userId)
+
+                every { cardRepository.findAllByIds(setOf(300L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                )
+                every {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L), userId)
+                } returns listOf(card)
+                // 노트 200 은 삭제 대상(300) 외에 아직 산 카드가 있어 survivor 로 반환됨 → 고아 아님
+                every {
+                    cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L), listOf(300L))
+                } returns listOf(200L)
+
+                cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L)))
+
                 card.isDeleted.shouldBeTrue()
-                note.isDeleted.shouldBeFalse()
+                sharedNote.isDeleted.shouldBeFalse()
+                deck.cardCount shouldBe 2
+            }
+
+            it("여러 덱에 걸친 카드를 삭제하면 덱별로 이벤트를 각각 발행한다") {
+                val userId = 1L
+                val noteType = newNoteType(id = 1L)
+                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
+                val deckA = newDeck(id = 10L, userId = userId, cardCount = 2)
+                val deckB = newDeck(id = 11L, userId = userId, cardCount = 2)
+                val noteA = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
+                val noteB = newNote(id = 201L, userId = userId, fields = mapOf("front" to "b"))
+                val cardA = newCard(id = 300L, template = tpl, note = noteA, deck = deckA, userId = userId)
+                val cardB = newCard(id = 301L, template = tpl, note = noteB, deck = deckB, userId = userId)
+
+                every { cardRepository.findAllByIds(setOf(300L, 301L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                    CardOwnership(id = 301L, userId = userId, deletedAt = null),
+                )
+                every {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L, 301L), userId)
+                } returns listOf(cardA, cardB)
+                every {
+                    cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L, 201L), listOf(300L, 301L))
+                } returns emptyList()
+
+                cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L, 301L)))
+
+                deckA.cardCount shouldBe 1
+                deckB.cardCount shouldBe 1
+                verify {
+                    eventPublisher.publishEvent(
+                        CardsDeletedEvent(
+                            deckId = 10L,
+                            deletedCount = 1,
+                            userId = userId,
+                            deletedCardIds = setOf(300L),
+                            deletedAt = fixedNow,
+                        ),
+                    )
+                    eventPublisher.publishEvent(
+                        CardsDeletedEvent(
+                            deckId = 11L,
+                            deletedCount = 1,
+                            userId = userId,
+                            deletedCardIds = setOf(301L),
+                            deletedAt = fixedNow,
+                        ),
+                    )
+                }
+            }
+
+            it("일부는 살아있고 일부는 이미 삭제된 경우, 산 카드만 삭제하고 응답 카운트는 요청 중 존재하는 전체 수(정책 B)다") {
+                val userId = 1L
+                val noteType = newNoteType(id = 1L)
+                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
+                val deck = newDeck(id = 10L, userId = userId, cardCount = 3)
+                val note = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
+                val aliveCard = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
+
+                every { cardRepository.findAllByIds(setOf(300L, 301L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null), // 살아있음
+                    CardOwnership(id = 301L, userId = userId, deletedAt = fixedNow), // 이미 삭제됨
+                )
+                every {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L), userId)
+                } returns listOf(aliveCard)
+                every {
+                    cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L), listOf(300L))
+                } returns emptyList()
+
+                val result = cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L, 301L)))
+
+                result.deletedCardsCount shouldBe 2 // B: 300(산 것) + 301(이미 삭제) 모두 "결과적 삭제 상태"
+                aliveCard.isDeleted.shouldBeTrue()
                 deck.cardCount shouldBe 2
                 verify {
                     eventPublisher.publishEvent(
@@ -505,66 +626,102 @@ class CardServiceUnitTest :
                             deckId = 10L,
                             deletedCount = 1,
                             userId = userId,
-                            deletedCardIds = setOf(card.id),
+                            deletedCardIds = setOf(300L),
                             deletedAt = fixedNow,
                         ),
                     )
                 }
             }
 
-            it("같은 노트의 마지막 카드면 노트도 함께 soft delete 한다") {
+            it("타인 소유 카드가 하나라도 섞이면 CardForbiddenException 을 던지고 아무것도 삭제/발행하지 않는다") {
                 val userId = 1L
-                val noteType = newNoteType(id = 1L)
-                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
-                val note = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
-                val deck = newDeck(id = 10L, userId = userId, cardCount = 1)
-                val card = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
-
-                every { cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(300L) } returns card
-                every { cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(200L, 300L) } returns 0L
-
-                cardService.deleteCard(userId, DeleteCardDto(cardId = 300L))
-
-                card.isDeleted.shouldBeTrue()
-                note.isDeleted.shouldBeTrue()
-                deck.cardCount shouldBe 0
-            }
-
-            it("cardCount 가 이미 0 이면 음수로 내려가지 않고 0 으로 유지된다") {
-                val userId = 1L
-                val noteType = newNoteType(id = 1L)
-                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
-                val note = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
-                val deck = newDeck(id = 10L, userId = userId, cardCount = 0)
-                val card = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
-
-                every { cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(300L) } returns card
-                every { cardRepository.countByNoteIdAndDeletedAtIsNullAndIdNot(200L, 300L) } returns 0L
-
-                cardService.deleteCard(userId, DeleteCardDto(cardId = 300L))
-
-                deck.cardCount shouldBe 0
-            }
-
-            it("카드가 없으면 CardNotFoundException 을 던진다") {
-                every { cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(999L) } returns null
-
-                shouldThrow<CardNotFoundException> {
-                    cardService.deleteCard(userId = 1L, dto = DeleteCardDto(cardId = 999L))
-                }
-            }
-
-            it("다른 유저의 카드면 CardForbiddenException 을 던진다") {
-                val noteType = newNoteType(id = 1L)
-                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
-                val note = newNote(id = 200L, userId = 2L, fields = mapOf("front" to "x"))
-                val deck = newDeck(id = 10L, userId = 2L)
-                val card = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = 2L)
-                every { cardRepository.findByIdAndDeletedAtIsNullWithNoteAndTemplate(300L) } returns card
+                every { cardRepository.findAllByIds(setOf(300L, 301L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                    CardOwnership(id = 301L, userId = 2L, deletedAt = null), // 타인 소유
+                )
 
                 shouldThrow<CardForbiddenException> {
-                    cardService.deleteCard(userId = 1L, dto = DeleteCardDto(cardId = 300L))
+                    cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L, 301L)))
                 }
+                verify(exactly = 0) { eventPublisher.publishEvent(any()) }
+                verify(exactly = 0) {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(any(), any())
+                }
+            }
+
+            it("존재하지 않는 카드만 요청하면 삭제/발행 없이 0 을 반환한다(멱등)") {
+                val userId = 1L
+                every { cardRepository.findAllByIds(setOf(999L)) } returns emptyList()
+
+                val result = cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(999L)))
+
+                result.deletedCardsCount shouldBe 0
+                verify(exactly = 0) { eventPublisher.publishEvent(any()) }
+            }
+
+            it("이미 삭제된 카드만 요청하면 삭제/발행 없이 종료한다") {
+                val userId = 1L
+                every { cardRepository.findAllByIds(setOf(300L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = fixedNow), // 이미 삭제됨
+                )
+
+                val result = cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L)))
+
+                result.deletedCardsCount shouldBe 1
+                verify(exactly = 0) { eventPublisher.publishEvent(any()) }
+            }
+
+            it("덱 cardCount 가 이미 0 이어도 음수로 내려가지 않고 0 으로 유지된다") {
+                val userId = 1L
+                val noteType = newNoteType(id = 1L)
+                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
+                val deck = newDeck(id = 10L, userId = userId, cardCount = 0)
+                val note = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
+                val card = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
+
+                every { cardRepository.findAllByIds(setOf(300L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                )
+                every {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L), userId)
+                } returns listOf(card)
+                every {
+                    cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L), listOf(300L))
+                } returns emptyList()
+
+                cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L)))
+
+                deck.cardCount shouldBe 0
+            }
+
+            it("한 요청에 고아가 되는 노트와 살아남는 노트가 섞이면 고아 노트만 삭제한다") {
+                val userId = 1L
+                val noteType = newNoteType(id = 1L)
+                val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
+                val deck = newDeck(id = 10L, userId = userId, cardCount = 5)
+                val orphanNote = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a")) // 마지막 카드 삭제 → 고아
+                val sharedNote = newNote(id = 201L, userId = userId, fields = mapOf("front" to "b")) // 다른 산 카드 있음 → 생존
+                val card1 = newCard(id = 300L, template = tpl, note = orphanNote, deck = deck, userId = userId)
+                val card2 = newCard(id = 301L, template = tpl, note = sharedNote, deck = deck, userId = userId)
+
+                every { cardRepository.findAllByIds(setOf(300L, 301L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                    CardOwnership(id = 301L, userId = userId, deletedAt = null),
+                )
+                every {
+                    cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L, 301L), userId)
+                } returns listOf(card1, card2)
+                // 노트 201(sharedNote)만 survivor 로 반환 → 노트 200(orphanNote)만 고아
+                every {
+                    cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L, 201L), listOf(300L, 301L))
+                } returns listOf(201L)
+
+                cardService.deleteCard(userId, DeleteCardDto(cardIds = setOf(300L, 301L)))
+
+                card1.isDeleted.shouldBeTrue()
+                card2.isDeleted.shouldBeTrue()
+                orphanNote.isDeleted.shouldBeTrue()
+                sharedNote.isDeleted.shouldBeFalse()
             }
         }
 

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardServiceUnitTest.kt
@@ -67,6 +67,9 @@ class CardServiceUnitTest :
                 cardTemplateRepository,
                 eventPublisher,
             )
+            // 카드 수 증감은 원자적 UPDATE(리포지토리 호출)로 처리 — 반환값은 검증에 쓰지 않으므로 공통 스텁
+            every { deckRepository.increaseCardCount(any(), any()) } returns 1
+            every { deckRepository.decreaseCardCount(any(), any()) } returns 1
         }
 
         fun setId(
@@ -174,7 +177,7 @@ class CardServiceUnitTest :
                 result.items[0].fields shouldBe mapOf("front" to "apple")
                 result.items[1].cardId shouldBe 301L
                 result.items[1].fields shouldBe mapOf("back" to "사과")
-                deck.cardCount shouldBe 7
+                verify { deckRepository.increaseCardCount(deckId, 2) }
                 verify {
                     eventPublisher.publishEvent(
                         CardsCreatedEvent(cardIds = listOf(300L, 301L), deckId = deckId, userId = userId),
@@ -217,7 +220,7 @@ class CardServiceUnitTest :
                 val result = cardService.createCards(userId, dto)
 
                 result.items shouldHaveSize 4
-                deck.cardCount shouldBe 4
+                verify { deckRepository.increaseCardCount(deckId, 4) }
                 result.items.map { it.cardId } shouldContainExactlyInAnyOrder listOf(300L, 301L, 302L, 303L)
             }
 
@@ -510,7 +513,7 @@ class CardServiceUnitTest :
                 card2.isDeleted.shouldBeTrue()
                 note1.isDeleted.shouldBeTrue()
                 note2.isDeleted.shouldBeTrue()
-                deck.cardCount shouldBe 3
+                verify { deckRepository.decreaseCardCount(10L, 2) }
                 verify {
                     eventPublisher.publishEvent(
                         CardsDeletedEvent(
@@ -548,7 +551,7 @@ class CardServiceUnitTest :
 
                 card.isDeleted.shouldBeTrue()
                 sharedNote.isDeleted.shouldBeFalse()
-                deck.cardCount shouldBe 2
+                verify { deckRepository.decreaseCardCount(10L, 1) }
             }
 
             it("여러 덱에 걸친 카드를 삭제하면 덱별로 이벤트를 각각 발행한다") {
@@ -575,8 +578,8 @@ class CardServiceUnitTest :
 
                 cardService.deleteCard(userId, clientTimezone, DeleteCardDto(cardIds = setOf(300L, 301L)))
 
-                deckA.cardCount shouldBe 1
-                deckB.cardCount shouldBe 1
+                verify { deckRepository.decreaseCardCount(10L, 1) }
+                verify { deckRepository.decreaseCardCount(11L, 1) }
                 verify {
                     eventPublisher.publishEvent(
                         CardsDeletedEvent(
@@ -624,7 +627,7 @@ class CardServiceUnitTest :
 
                 result.deletedCardsCount shouldBe 2 // B: 300(산 것) + 301(이미 삭제) 모두 "결과적 삭제 상태"
                 aliveCard.isDeleted.shouldBeTrue()
-                deck.cardCount shouldBe 2
+                verify { deckRepository.decreaseCardCount(10L, 1) }
                 verify {
                     eventPublisher.publishEvent(
                         CardsDeletedEvent(
@@ -677,27 +680,28 @@ class CardServiceUnitTest :
                 verify(exactly = 0) { eventPublisher.publishEvent(any()) }
             }
 
-            it("덱 cardCount 가 이미 0 이어도 음수로 내려가지 않고 0 으로 유지된다") {
+            it("타인의 이미 삭제된 카드가 섞여도 count 에 포함하지 않는다 (내 카드만 카운트)") {
                 val userId = 1L
                 val noteType = newNoteType(id = 1L)
                 val tpl = newTemplate(id = 100L, noteType = noteType, requiredFields = listOf("front"))
-                val deck = newDeck(id = 10L, userId = userId, cardCount = 0)
+                val deck = newDeck(id = 10L, userId = userId, cardCount = 3)
                 val note = newNote(id = 200L, userId = userId, fields = mapOf("front" to "a"))
-                val card = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
+                val myAliveCard = newCard(id = 300L, template = tpl, note = note, deck = deck, userId = userId)
 
-                every { cardRepository.findAllByIds(setOf(300L)) } returns listOf(
-                    CardOwnership(id = 300L, userId = userId, deletedAt = null),
+                every { cardRepository.findAllByIds(setOf(300L, 301L)) } returns listOf(
+                    CardOwnership(id = 300L, userId = userId, deletedAt = null), // 내 산 카드
+                    CardOwnership(id = 301L, userId = 2L, deletedAt = fixedNow), // 타인의 이미 삭제된 카드
                 )
                 every {
                     cardRepository.findAllByIdInAndUserIdAndDeletedAtIsNullWithNoteAndTemplate(listOf(300L), userId)
-                } returns listOf(card)
+                } returns listOf(myAliveCard)
                 every {
                     cardRepository.findSurvivorNoteIdsByNoteIdInExcludingCards(setOf(200L), listOf(300L))
                 } returns emptyList()
 
-                cardService.deleteCard(userId, clientTimezone, DeleteCardDto(cardIds = setOf(300L)))
+                val result = cardService.deleteCard(userId, clientTimezone, DeleteCardDto(cardIds = setOf(300L, 301L)))
 
-                deck.cardCount shouldBe 0
+                result.deletedCardsCount shouldBe 1 // 타인 카드(301)는 제외, 내 카드(300)만 카운트
             }
 
             it("한 요청에 고아가 되는 노트와 살아남는 노트가 섞이면 고아 노트만 삭제한다") {

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/DeckRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/DeckRepositoryTest.kt
@@ -1,0 +1,67 @@
+package com.whatever.caro.card.internal.deck
+
+import com.whatever.caro.TestcontainersConfiguration
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.context.annotation.Import
+import org.springframework.modulith.test.ApplicationModuleTest
+import org.springframework.transaction.annotation.Transactional
+
+@ApplicationModuleTest(extraIncludes = ["common"])
+@Import(TestcontainersConfiguration::class)
+@Transactional
+class DeckRepositoryTest(
+    private val deckRepository: DeckRepository,
+) : DescribeSpec({
+
+    afterEach { deckRepository.deleteAllInBatch() }
+
+    fun saveDeck(
+        cardCount: Int,
+    ): Deck = deckRepository.save(Deck(userId = 1L, name = "덱", description = "설명", cardCount = cardCount))
+
+    describe("decreaseCardCount") {
+        it("카드 개수를 감소시키고 수정된 행 수를 반환한다") {
+            // given
+            val deck = saveDeck(cardCount = 10)
+
+            // when
+            val updated = deckRepository.decreaseCardCount(
+                deckId = deck.id,
+                amount = 3,
+            )
+
+            // then
+            updated shouldBe 1
+            deckRepository.findById(deck.id).get().cardCount shouldBe 7
+        }
+
+        it("존재하지 않는 덱이면 수정된 행 수는 0이다") {
+            // when
+            val updated = deckRepository.decreaseCardCount(
+                deckId = Long.MAX_VALUE,
+                amount = 3,
+            )
+
+            // then
+            updated shouldBe 0
+        }
+    }
+
+    describe("increaseCardCount") {
+        it("카드 개수를 증가시키고 수정된 행 수를 반환한다") {
+            val deck = saveDeck(cardCount = 5)
+
+            val updated = deckRepository.increaseCardCount(deck.id, 2)
+
+            updated shouldBe 1
+            deckRepository.findById(deck.id).get().cardCount shouldBe 7
+        }
+
+        it("존재하지 않는 덱이면 수정된 행 수는 0이다") {
+            val updated = deckRepository.increaseCardCount(Long.MAX_VALUE, 2)
+
+            updated shouldBe 0
+        }
+    }
+})


### PR DESCRIPTION
## 📌 Related Issue
Closes #58

## 📝 Changes
- 카드 대량으로 삭제할 수 있도록 했어요
- path 에서 id가 빠지고, body로 삭제할 id들을 넘겨줍니다
- 내 것이 아닌 id가 껴있다면 전부 실패합니다 (  멱등성 있게 수행하는게 맞다고 생각했어요 delete라서 )
-  삭제 이벤트 발행은 덱별로 수행하게끔 변경했어요 ~! 


## ✅ Checklist
- [x] 테스트 완료
- [ ] 리뷰 준비 완료

## 📋 Additional Notes(Optional)