### PR TITLE
[Feat] 일일학습 평가 endpoint에 평가 결과 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -21,7 +21,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-@Tag(name = "Deck Card Information", description = "Deck card information")
+@Tag(name = "Deck", description = "단어/표현 덱 관리")
 @RestController
 class DeckBFFController(
     private val clock: Clock,

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -16,7 +16,9 @@ import com.whatever.caro.card.internal.card.dto.update.UpdateCardResponse
 import com.whatever.caro.card.internal.card.dto.update.toDto
 import com.whatever.caro.card.internal.card.dto.update.toResponse
 import com.whatever.caro.common.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import org.springframework.http.ResponseEntity
@@ -31,11 +33,16 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 import java.time.ZoneId
 
+@Tag(name = "Card", description = "카드 관리")
 @Validated
 @RestController
 class CardController(
     private val cardService: CardService,
 ) {
+    @Operation(
+        summary = "카드 생성",
+        description = "덱에 여러 카드를 한 번에 생성한다.",
+    )
     @PostMapping("/v1/decks/{deckId}/cards")
     fun createCards(
         @Parameter(description = "덱 ID", required = true)
@@ -47,6 +54,11 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
+    @Operation(
+        summary = "덱의 카드 목록 조회 (deprecated)",
+        description = "덱에 속한 카드 목록을 조회한다. 학습 상태(badge/복습 수)가 포함된 `GET /v2/decks/{deckId}/cards` 로 대체되었다.",
+        deprecated = true,
+    )
     @Deprecated(message = "v2 메서드로 변경 필요")
     @GetMapping("/v1/decks/{deckId}/cards")
     fun getCardsByDeck(
@@ -58,6 +70,10 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
+    @Operation(
+        summary = "카드 단건 조회",
+        description = "카드 ID로 카드 1건을 조회한다.",
+    )
     @GetMapping("/v1/cards/{id}")
     fun getCard(
         @Parameter(description = "카드 ID", required = true)
@@ -68,6 +84,10 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
+    @Operation(
+        summary = "카드 수정",
+        description = "카드의 필드 값을 수정한다.",
+    )
     @PatchMapping("/v1/cards/{id}")
     fun updateCard(
         @Parameter(description = "카드 ID", required = true)
@@ -79,6 +99,13 @@ class CardController(
         return ResponseEntity.ok(ApiResponse.ok(result))
     }
 
+    @Operation(
+        summary = "카드 삭제",
+        description = """
+        카드를 삭제(soft delete)한다.
+        삭제는 일일학습 목표/진행도와 streak 계산에 반영되므로 `Client-Timezone` 헤더로 사용자의 오늘 경계를 판단한다.
+        """,
+    )
     @DeleteMapping("/v1/cards")
     fun deleteCards(
         @RequestHeader("Client-Timezone", required = true)

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
@@ -50,6 +50,10 @@ class DeckController(
         return ResponseEntity.ok(ApiResponse.ok(deck))
     }
 
+    @Operation(
+        summary = "덱 삭제",
+        description = "덱을 삭제한다. 덱에 속한 카드와 학습 상태도 함께 정리된다.",
+    )
     @DeleteMapping("/{deckId}")
     fun deleteDeck(
         @Parameter(description = "덱 ID", required = true)
@@ -63,6 +67,10 @@ class DeckController(
         return ResponseEntity.ok(ApiResponse.ok(deck))
     }
 
+    @Operation(
+        summary = "덱 수정",
+        description = "덱의 이름/설명 등 메타데이터를 수정한다.",
+    )
     @PatchMapping("/{deckId}")
     fun updateDeck(
         @Parameter(description = "덱 ID", required = true)

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationResult.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationResult.kt
@@ -6,4 +6,11 @@ data class EvaluationResult(
     val evaluatedItems: List<ValidItem>,
     val failedItems: List<InvalidItem>,
     val sessionStatus: StudySessionStatus,
+    val ratingCounts: RatingCounts,
+)
+
+data class RatingCounts(
+    val again: Int,
+    val fair: Int,
+    val easy: Int,
 )

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
@@ -142,6 +142,7 @@ sealed interface ValidationResult
 data class ValidItem(
     val item: EvaluatedCardDto,
 ) : ValidationResult
+
 data class InvalidItem(
     val item: EvaluatedCardDto,
 ) : ValidationResult
@@ -157,9 +158,11 @@ private fun DeckPresetDto.toSm2Params(): Sm2Params =
         leechThreshold = leechThreshold,
     )
 
-private fun List<ReviewLog>.toRatingCounts(): RatingCounts =
-    RatingCounts(
-        again = count { it.rating == Rating.AGAIN },
-        fair = count { it.rating == Rating.FAIR },
-        easy = count { it.rating == Rating.EASY },
+private fun List<ReviewLog>.toRatingCounts(): RatingCounts {
+    val counts = this.groupingBy { it.rating }.eachCount()
+    return RatingCounts(
+        again = counts[Rating.AGAIN] ?: 0,
+        fair = counts[Rating.FAIR] ?: 0,
+        easy = counts[Rating.EASY] ?: 0,
     )
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/EvaluationService.kt
@@ -4,6 +4,7 @@ import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.card.api.deck.DeckPresetDto
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.DailyStudyCompletedEvent
+import com.whatever.caro.study.Rating
 import com.whatever.caro.study.ReviewType
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.exception.SessionExpiredException
@@ -55,7 +56,8 @@ class EvaluationService(
             cardIds = dedupedItems.map { it.cardId },
         ).associateBy { it.cardId }
 
-        val evaluatedCardIds = reviewLogRepository.findAllByStudySessionId(session.id).map { it.cardId }.toSet()
+        val existingReviewLogs = reviewLogRepository.findAllByStudySessionId(session.id)
+        val evaluatedCardIds = existingReviewLogs.map { it.cardId }.toSet()
         val validationResults = dedupedItems.map {
             EvaluationItemValidator.validate(
                 item = it,
@@ -110,6 +112,7 @@ class EvaluationService(
             evaluatedItems = validItems,
             failedItems = invalidItems,
             sessionStatus = session.status,
+            ratingCounts = (existingReviewLogs + newReviewLogs).toRatingCounts(),
         )
     }
 }
@@ -152,4 +155,11 @@ private fun DeckPresetDto.toSm2Params(): Sm2Params =
         lapseIntervalMultiplier = lapseIntervalMultiplier,
         lapseMinInterval = lapseMinInterval,
         leechThreshold = leechThreshold,
+    )
+
+private fun List<ReviewLog>.toRatingCounts(): RatingCounts =
+    RatingCounts(
+        again = count { it.rating == Rating.AGAIN },
+        fair = count { it.rating == Rating.FAIR },
+        easy = count { it.rating == Rating.EASY },
     )

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/EvaluationController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/EvaluationController.kt
@@ -1,6 +1,7 @@
 package com.whatever.caro.study.internal.web
 
 import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.common.web.idempotency.Idempotent
 import com.whatever.caro.study.internal.EvaluatedCardDto
 import com.whatever.caro.study.internal.EvaluationService
@@ -48,7 +49,7 @@ class EvaluationController(
         @RequestHeader("Client-Timezone", required = true) clientTimezone: ZoneId,
         @Positive @PathVariable(required = true) sessionId: Long,
         @Valid @RequestBody items: List<EvaluatedCardRequest>,
-    ): ResponseEntity<EvaluationResponse> {
+    ): ResponseEntity<ApiResponse<EvaluationResponse>> {
         val now = Instant.now(clock)
         val result = evaluationService.evaluate(
             now = now,
@@ -58,7 +59,7 @@ class EvaluationController(
             items = items.map { it.toDto() },
         )
 
-        return ResponseEntity.ok(EvaluationResponse.from(result))
+        return ResponseEntity.ok(ApiResponse.ok(EvaluationResponse.from(result)))
     }
 }
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
@@ -1,6 +1,7 @@
 package com.whatever.caro.study.internal.web
 
 import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.study.internal.streak.StreakService
 import com.whatever.caro.study.internal.web.response.StreakResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -30,7 +31,7 @@ class StreakController(
     @GetMapping
     fun getStreak(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
-    ): ResponseEntity<StreakResponse> {
+    ): ResponseEntity<ApiResponse<StreakResponse>> {
         val now = Instant.now(clock)
         val currentStreak = streakService.getStreak(
             userId = SecurityUtil.currentUser().userId,
@@ -38,13 +39,13 @@ class StreakController(
             timezone = timezone,
             dayCutoffHour = 0,
         )
-        return ResponseEntity.ok(StreakResponse(currentStreak = currentStreak))
+        return ResponseEntity.ok(ApiResponse.ok(StreakResponse(currentStreak = currentStreak)))
     }
 
     @PostMapping("/sync")
     fun syncStreak(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
-    ) {
+    ): ResponseEntity<ApiResponse<Unit>> {
         val now = Instant.now(clock)
         streakService.syncWithRestDayCheck(
             userId = SecurityUtil.currentUser().userId,
@@ -52,5 +53,6 @@ class StreakController(
             timezone = timezone,
             dayCutoffHour = 0,
         )
+        return ResponseEntity.ok(ApiResponse.ok(Unit))
     }
 }

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
@@ -42,6 +42,13 @@ class StreakController(
         return ResponseEntity.ok(ApiResponse.ok(StreakResponse(currentStreak = currentStreak)))
     }
 
+    @Operation(
+        summary = "streak 동기화",
+        description = """
+        오늘까지의 학습 이력을 기준으로 휴식일 여부를 확인한 뒤 streak을 동기화한다.
+        오프라인 학습 후 재접속 시 클라이언트가 호출해 서버 streak을 최신 상태로 맞추는 용도이다.
+        """,
+    )
     @PostMapping("/sync")
     fun syncStreak(
         @RequestHeader("Client-Timezone") timezone: ZoneId,

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StudyController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StudyController.kt
@@ -25,6 +25,14 @@ class StudyController(
     private val studyService: StudyService,
 ) {
 
+    @Operation(
+        summary = "오늘 일일학습 요약 조회",
+        description = """
+        특정 덱의 오늘 일일학습 상태를 조회한다.
+        상태에 따라 미시작(NotStarted) / 진행중(InProgress) / 완료(Completed) / 휴식일(RestDay)로 응답하며,
+        각 상태에서 학습한 카드 수와 오늘 목표 카드 수를 함께 제공한다.
+        """,
+    )
     @GetMapping("/daily/summary")
     fun getTodayDailyStudySummary(
         @RequestHeader("Client-Timezone") timezone: ZoneId,

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StudyController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StudyController.kt
@@ -1,9 +1,11 @@
 package com.whatever.caro.study.internal.web
 
 import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.study.TodayStudySessionState
 import com.whatever.caro.study.internal.StudyService
 import com.whatever.caro.study.internal.web.response.DailyStudySummaryResponse
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,7 +29,7 @@ class StudyController(
     fun getTodayDailyStudySummary(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
         @RequestParam(value = "deckId", required = true) deckId: Long,
-    ): ResponseEntity<DailyStudySummaryResponse> {
+    ): ResponseEntity<ApiResponse<DailyStudySummaryResponse>> {
         val now = Instant.now(clock)
         val studySession = studyService.getTodaySummary(
             now = now,
@@ -36,7 +38,7 @@ class StudyController(
             deckId = deckId,
         )
 
-        return ResponseEntity.ok(studySession.toResponse())
+        return ResponseEntity.ok(ApiResponse.ok(studySession.toResponse()))
     }
 }
 

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/response/EvaluationResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/response/EvaluationResponse.kt
@@ -2,11 +2,18 @@ package com.whatever.caro.study.internal.web.response
 
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.internal.EvaluationResult
+import com.whatever.caro.study.internal.RatingCounts
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class EvaluationResponse(
+    @Schema(description = "평가가 완료된 카드 id")
     val evaluatedCardIds: List<Long>,
+    @Schema(description = "평가에 실패한 카드 id, 일반적인 케이스에서 나오지 않음")
     val failedCardIds: List<Long>,
+    @Schema(description = "평가 시점 세션의 상태")
     val sessionStatus: StudySessionStatus,
+    @Schema(description = "세션 전체 누적 등급별 카운트(중단 이전 평가 포함). again=모르겠어요, fair=애매해요, easy=쉬워요")
+    val ratingCounts: RatingCounts,
 ) {
     companion object {
         fun from(
@@ -15,6 +22,7 @@ data class EvaluationResponse(
             evaluatedCardIds = result.evaluatedItems.map { it.item.cardId },
             failedCardIds = result.failedItems.map { it.item.cardId },
             sessionStatus = result.sessionStatus,
+            ratingCounts = result.ratingCounts,
         )
     }
 }

--- a/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
@@ -537,6 +537,106 @@ class EvaluationServiceTest(
                 studySessionRepository.findByIdOrNull(session.id)!!.newCardsStudied shouldBe 0
             }
         }
+
+        context("등급별 카운트 집계") {
+            it("혼합 등급 평가 시 ratingCounts가 등급별로 정확히 집계된다") {
+                stubPreset()
+                val session = createSession()
+                val cls1 = createCls(cardId = 1L, status = CardLearningStatus.NEW)
+                val cls2 = createCls(cardId = 2L, status = CardLearningStatus.NEW)
+                val cls3 = createCls(cardId = 3L, status = CardLearningStatus.NEW)
+                val cls4 = createCls(cardId = 4L, status = CardLearningStatus.NEW)
+
+                val result = evaluationService.evaluate(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    sessionId = session.id,
+                    items = listOf(
+                        getEvaluatedCardDto(cardId = cls1.cardId, rating = Rating.AGAIN),
+                        getEvaluatedCardDto(cardId = cls2.cardId, rating = Rating.FAIR),
+                        getEvaluatedCardDto(cardId = cls3.cardId, rating = Rating.FAIR),
+                        getEvaluatedCardDto(cardId = cls4.cardId, rating = Rating.EASY),
+                    ),
+                )
+
+                result.ratingCounts shouldBe RatingCounts(again = 1, fair = 2, easy = 1)
+
+                val updatedSession = studySessionRepository.findByIdOrNull(session.id)!!
+                (result.ratingCounts.again + result.ratingCounts.fair + result.ratingCounts.easy) shouldBe
+                    (updatedSession.newCardsStudied + updatedSession.reviewCardsStudied)
+            }
+
+            it("중단 후 재개하여 완료한 경우 ratingCounts는 세션 전체 누적을 반환한다") {
+                stubPreset()
+                val session = createSession(newCardsGoal = 4, reviewCardsGoal = 0)
+                val cls1 = createCls(cardId = 1L, status = CardLearningStatus.NEW)
+                val cls2 = createCls(cardId = 2L, status = CardLearningStatus.NEW)
+                val cls3 = createCls(cardId = 3L, status = CardLearningStatus.NEW)
+                val cls4 = createCls(cardId = 4L, status = CardLearningStatus.NEW)
+
+                val result1 = evaluationService.evaluate(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    sessionId = session.id,
+                    items = listOf(
+                        getEvaluatedCardDto(cardId = cls1.cardId, rating = Rating.AGAIN),
+                        getEvaluatedCardDto(cardId = cls2.cardId, rating = Rating.FAIR),
+                    ),
+                )
+                result1.ratingCounts shouldBe RatingCounts(again = 1, fair = 1, easy = 0)
+
+                val result2 = evaluationService.evaluate(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    sessionId = session.id,
+                    items = listOf(
+                        getEvaluatedCardDto(cardId = cls3.cardId, rating = Rating.EASY),
+                        getEvaluatedCardDto(cardId = cls4.cardId, rating = Rating.EASY),
+                    ),
+                )
+
+                result2.ratingCounts shouldBe RatingCounts(again = 1, fair = 1, easy = 2)
+                result2.sessionStatus shouldBe StudySessionStatus.COMPLETED
+
+                val updatedSession = studySessionRepository.findByIdOrNull(session.id)!!
+                (result2.ratingCounts.again + result2.ratingCounts.fair + result2.ratingCounts.easy) shouldBe
+                    (updatedSession.newCardsStudied + updatedSession.reviewCardsStudied)
+            }
+
+            it("무효 항목은 ratingCounts에 반영되지 않고 기존 누적을 유지한다") {
+                stubPreset()
+                val session = createSession()
+                val cls1 = createCls(cardId = 1L, status = CardLearningStatus.NEW)
+                val cls2 = createCls(cardId = 2L, status = CardLearningStatus.NEW)
+
+                val result1 = evaluationService.evaluate(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    sessionId = session.id,
+                    items = listOf(getEvaluatedCardDto(cardId = cls1.cardId, rating = Rating.AGAIN)),
+                )
+                result1.ratingCounts shouldBe RatingCounts(again = 1, fair = 0, easy = 0)
+
+                val result2 = evaluationService.evaluate(
+                    now = baseNow,
+                    timezone = kstZoneId,
+                    userId = USER_ID,
+                    sessionId = session.id,
+                    items = listOf(
+                        getEvaluatedCardDto(cardId = cls1.cardId, rating = Rating.EASY),
+                        getEvaluatedCardDto(cardId = cls2.cardId, rating = Rating.FAIR, timeMs = -1),
+                    ),
+                )
+
+                result2.ratingCounts shouldBe RatingCounts(again = 1, fair = 0, easy = 0)
+                result2.failedItems.size shouldBe 2
+                result2.evaluatedItems.size shouldBe 0
+            }
+        }
     }
 }) {
     companion object {


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
- 클라이언트에서 평과 결과를 활용할 수 있도록, 평가 요청마다 응답으로 결과를 함께 반환
- 공통 response 양식이 적용되지 않았던 endpoint에 공통 response 적용
- swagger 문서 정리


## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)