### PR TITLE
[Feat] 덱 카드 목록 조회 정렬 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/bff/internal/CardSortType.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/CardSortType.kt
@@ -1,0 +1,7 @@
+package com.whatever.caro.bff.internal
+
+enum class CardSortType {
+    CREATED,
+    LAST_REVIEWED,
+    REVIEW_FREQUENCY,
+}

--- a/src/main/kotlin/com/whatever/caro/bff/internal/CardSorter.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/CardSorter.kt
@@ -1,0 +1,25 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.study.CardLearningStateDto
+
+internal data class CardWithState(
+    val card: CardContentDto,
+    val state: CardLearningStateDto?,
+)
+
+internal fun CardSortType.comparator(): Comparator<CardWithState> {
+    val primary: Comparator<CardWithState> = when (this) {
+        CardSortType.CREATED -> Comparator { _, _ -> 0 }
+
+        // 생성일(card id)정렬을 위해 동률로 처리
+        CardSortType.LAST_REVIEWED -> compareBy(nullsLast(reverseOrder())) {
+            it.state?.lastReviewedDate
+        }
+
+        CardSortType.REVIEW_FREQUENCY -> compareByDescending {
+            it.state?.totalReviews ?: 0
+        }
+    }
+    return primary.thenByDescending { it.card.cardId }
+}

--- a/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/DeckBFFService.kt
@@ -1,7 +1,6 @@
 package com.whatever.caro.bff.internal
 
 import com.whatever.caro.card.api.card.CardApi
-import com.whatever.caro.card.api.card.CardContentDto
 import com.whatever.caro.card.api.deck.DeckApi
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.study.CardLearningStateDto
@@ -23,6 +22,7 @@ class DeckBFFService(
     fun getCardsWithLearningState(
         userId: Long,
         deckId: Long,
+        sortType: CardSortType,
     ): List<DeckCardItem> {
         val cards = cardApi.getCardContentsByDeck(
             userId = userId,
@@ -35,13 +35,10 @@ class DeckBFFService(
         )
         val deckPreset = deckPresetApi.getLatestDeckPresetByUser(deckId, userId)
 
-        return cards.map { card ->
-            toDeckCardItem(
-                card = card,
-                state = learningStateByCardId[card.cardId],
-                hardBadgeThreshold = deckPreset.hardBadgeThreshold,
-            )
-        }
+        return cards
+            .map { CardWithState(card = it, state = learningStateByCardId[it.cardId]) }
+            .sortedWith(sortType.comparator())
+            .map { it.toDeckCardItem(hardBadgeThreshold = deckPreset.hardBadgeThreshold) }
     }
 
     fun getDecksWithDailyStudySession(
@@ -101,9 +98,7 @@ private fun TodayStudySessionState.toDeckProgress(): StudySessionProgress =
         )
     }
 
-private fun toDeckCardItem(
-    card: CardContentDto,
-    state: CardLearningStateDto?,
+private fun CardWithState.toDeckCardItem(
     hardBadgeThreshold: Int,
 ): DeckCardItem =
     DeckCardItem(

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -1,6 +1,7 @@
 package com.whatever.caro.bff.internal.web
 
 import com.whatever.caro.auth.SecurityUtil
+import com.whatever.caro.bff.internal.CardSortType
 import com.whatever.caro.bff.internal.DeckBFFService
 import com.whatever.caro.bff.internal.DeckCardItem
 import com.whatever.caro.bff.internal.DeckListItem
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.Clock
 import java.time.Instant
@@ -33,16 +35,24 @@ class DeckBFFController(
         description = """
         덱에 있는 모든 카드를 조회한다.
         각 카드별로 학습 상태를 기반으로 NEW/REVIEW/HARD badge, 복습 수가 함께 제공된다.
+
+        sortType에 따라 정렬된다 (기본값 CREATED). 동률은 항상 cardId 역순.
+        - CREATED: 최신 생성순 (cardId 역순)
+        - LAST_REVIEWED: 최근 복습일 역순. 미복습 카드는 목록 끝에 최신 생성순으로 배치
+        - REVIEW_FREQUENCY: 복습 수(reviewCount) 많은 순
         """,
     )
     @GetMapping("/v2/decks/{deckId}/cards")
     fun getCardsByDeck(
         @Parameter(description = "덱 ID", required = true) @PathVariable deckId: Long,
+        @Parameter(description = "정렬 기준 (기본값 CREATED)")
+        @RequestParam("sortType", defaultValue = "CREATED") sortType: CardSortType,
     ): ResponseEntity<ApiResponse<List<DeckCardResponse>>> {
         val userId = SecurityUtil.currentUser().userId
         val cards = deckBFFService.getCardsWithLearningState(
             userId = userId,
             deckId = deckId,
+            sortType = sortType,
         )
         return ResponseEntity.ok(ApiResponse.ok(cards.map { it.toResponse() }))
     }

--- a/src/main/kotlin/com/whatever/caro/study/CardLearningStateDto.kt
+++ b/src/main/kotlin/com/whatever/caro/study/CardLearningStateDto.kt
@@ -1,8 +1,11 @@
 package com.whatever.caro.study
 
+import java.time.LocalDate
+
 data class CardLearningStateDto(
     val cardId: Long,
     val status: CardLearningStatus,
     val totalReviews: Int,
     val consecutiveAgainCount: Int,
+    val lastReviewedDate: LocalDate?,
 )

--- a/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/StudyService.kt
@@ -296,6 +296,7 @@ private fun CardLearningState.toDto(): CardLearningStateDto =
         status = status,
         totalReviews = totalReviews,
         consecutiveAgainCount = consecutiveAgainCount,
+        lastReviewedDate = lastReviewedDate,
     )
 
 private fun StudySession.toDto(): StudySessionDto =

--- a/src/test/kotlin/com/whatever/caro/bff/internal/CardSorterTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/CardSorterTest.kt
@@ -1,0 +1,134 @@
+package com.whatever.caro.bff.internal
+
+import com.whatever.caro.card.api.card.CardContentDto
+import com.whatever.caro.study.CardLearningStateDto
+import com.whatever.caro.study.CardLearningStatus
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldContainExactly
+import java.time.LocalDate
+
+class CardSorterTest :
+    DescribeSpec({
+        fun cardWithState(
+            cardId: Long,
+            lastReviewedDate: LocalDate? = null,
+            totalReviews: Int = 0,
+            hasState: Boolean = true,
+        ): CardWithState =
+            CardWithState(
+                card = CardContentDto(
+                    cardId = cardId,
+                    fields = mapOf("front" to "Q$cardId", "back" to "A$cardId"),
+                ),
+                state = if (hasState) {
+                    CardLearningStateDto(
+                        cardId = cardId,
+                        status = CardLearningStatus.NEW,
+                        totalReviews = totalReviews,
+                        consecutiveAgainCount = 0,
+                        lastReviewedDate = lastReviewedDate,
+                    )
+                } else {
+                    null
+                },
+            )
+
+        fun List<CardWithState>.sortedIds(
+            sortType: CardSortType,
+        ): List<Long> = sortedWith(sortType.comparator()).map { it.card.cardId }
+
+        describe("CREATED") {
+            it("cardId 역순(최신 생성순)으로 정렬한다") {
+                val cards = listOf(
+                    cardWithState(cardId = 1L),
+                    cardWithState(cardId = 3L),
+                    cardWithState(cardId = 2L),
+                )
+
+                cards.sortedIds(CardSortType.CREATED) shouldContainExactly listOf(3L, 2L, 1L)
+            }
+        }
+
+        describe("LAST_REVIEWED") {
+            it("복습한 카드가 최근 복습일 역순으로 먼저 온다") {
+                val cards = listOf(
+                    cardWithState(cardId = 1L, lastReviewedDate = LocalDate.parse("2026-07-01")),
+                    cardWithState(cardId = 2L, lastReviewedDate = LocalDate.parse("2026-07-15")),
+                    cardWithState(cardId = 3L, lastReviewedDate = LocalDate.parse("2026-07-10")),
+                )
+
+                cards.sortedIds(CardSortType.LAST_REVIEWED) shouldContainExactly listOf(2L, 3L, 1L)
+            }
+
+            it("미복습 카드는 목록 끝에 cardId 역순으로 온다") {
+                val cards = listOf(
+                    // state가 미생성된 카드(백엔드 오류 시 발생)와, state는 있지만 복습 이력이 없는 카드 모두 미복습으로 취급
+                    cardWithState(cardId = 1L, hasState = false),
+                    cardWithState(cardId = 2L, lastReviewedDate = LocalDate.parse("2026-07-15")),
+                    cardWithState(cardId = 3L, lastReviewedDate = null),
+                )
+
+                cards.sortedIds(CardSortType.LAST_REVIEWED) shouldContainExactly listOf(2L, 3L, 1L)
+            }
+
+            it("같은 날 복습한 카드끼리는 cardId 역순으로 정렬한다") {
+                val sameDay = LocalDate.parse("2026-07-15")
+                val cards = listOf(
+                    cardWithState(cardId = 1L, lastReviewedDate = sameDay),
+                    cardWithState(cardId = 3L, lastReviewedDate = sameDay),
+                    cardWithState(cardId = 2L, lastReviewedDate = sameDay),
+                )
+
+                cards.sortedIds(CardSortType.LAST_REVIEWED) shouldContainExactly listOf(3L, 2L, 1L)
+            }
+        }
+
+        describe("REVIEW_FREQUENCY") {
+            it("totalReviews 역순으로 정렬한다") {
+                val cards = listOf(
+                    cardWithState(cardId = 1L, totalReviews = 3),
+                    cardWithState(cardId = 2L, totalReviews = 10),
+                    cardWithState(cardId = 3L, totalReviews = 5),
+                )
+
+                cards.sortedIds(CardSortType.REVIEW_FREQUENCY) shouldContainExactly listOf(2L, 3L, 1L)
+            }
+
+            it("state가 없는 카드는 0회로 취급되어 뒤로 간다") {
+                val cards = listOf(
+                    cardWithState(cardId = 1L, hasState = false),
+                    cardWithState(cardId = 2L, totalReviews = 1),
+                )
+
+                cards.sortedIds(CardSortType.REVIEW_FREQUENCY) shouldContainExactly listOf(2L, 1L)
+            }
+
+            it("복습 횟수가 같은 카드끼리는 cardId 역순으로 정렬한다") {
+                val sameReviewCount = 10
+                val cards = listOf(
+                    cardWithState(cardId = 1L, totalReviews = sameReviewCount),
+                    cardWithState(cardId = 3L, totalReviews = sameReviewCount),
+                    cardWithState(cardId = 2L, totalReviews = sameReviewCount),
+                )
+
+                cards.sortedIds(CardSortType.LAST_REVIEWED) shouldContainExactly listOf(3L, 2L, 1L)
+            }
+        }
+
+        context("공통 tiebreaker") {
+            withData(
+                nameFn = { "sortType=$it -> 조건이 같을 경우 cardId 역순으로 재정렬" },
+                CardSortType.entries.toList(),
+            ) { sortType ->
+                // 모든 정렬 기준 값이 동일한 카드들
+                val cards = listOf(
+                    cardWithState(cardId = 2L),
+                    cardWithState(cardId = 1L),
+                    cardWithState(cardId = 3L),
+                )
+
+                cards.sortedIds(sortType) shouldContainExactly listOf(3L, 2L, 1L)
+            }
+        }
+    })

--- a/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.math.BigDecimal
+import java.time.LocalDate
 
 class DeckBFFServiceUnitTest :
     DescribeSpec({
@@ -45,12 +46,14 @@ class DeckBFFServiceUnitTest :
             status: CardLearningStatus = CardLearningStatus.NEW,
             totalReviews: Int = 0,
             consecutiveAgainCount: Int = 0,
+            lastReviewedDate: LocalDate? = null,
         ): CardLearningStateDto =
             CardLearningStateDto(
                 cardId = cardId,
                 status = status,
                 totalReviews = totalReviews,
                 consecutiveAgainCount = consecutiveAgainCount,
+                lastReviewedDate = lastReviewedDate,
             )
 
         fun createPreset(
@@ -96,7 +99,7 @@ class DeckBFFServiceUnitTest :
 
         describe("getCardsWithLearningState") {
 
-            it("덱 카드들을 learningState/preset과 조합해 순서를 유지하며 DeckCardItem 리스트로 매핑한다") {
+            it("덱 카드들을 learningState/preset과 조합해 DeckCardItem 리스트로 매핑한다 (기본 정렬 CREATED = cardId 역순)") {
                 val cards = (1L..3L).map { i -> createCardContent(i) }
                 val states = listOf(
                     createCls(cardId = 1L, status = CardLearningStatus.NEW, totalReviews = 0, consecutiveAgainCount = 0),
@@ -105,16 +108,22 @@ class DeckBFFServiceUnitTest :
                 )
                 stubDeckInformation(cards = cards, states = states, hardBadgeThreshold = 8)
 
-                val result = service.getCardsWithLearningState(userId, deckId)
+                val result = service.getCardsWithLearningState(
+                    userId = userId,
+                    deckId = deckId,
+                    sortType = CardSortType.CREATED,
+                )
 
-                result.map { it.cardId } shouldContainExactly cards.map { it.cardId }
-                repeat(3) { i ->
-                    when (states[i].status) {
-                        CardLearningStatus.NEW -> result[i].badge shouldBe CardLearningStateBadge.NEW
-                        CardLearningStatus.REVIEW -> result[i].badge shouldBe CardLearningStateBadge.REVIEW
+                result.map { it.cardId } shouldContainExactly listOf(3L, 2L, 1L)
+                val itemByCardId = result.associateBy { it.cardId }
+                states.forEach { state ->
+                    val item = itemByCardId.getValue(state.cardId)
+                    when (state.status) {
+                        CardLearningStatus.NEW -> item.badge shouldBe CardLearningStateBadge.NEW
+                        CardLearningStatus.REVIEW -> item.badge shouldBe CardLearningStateBadge.REVIEW
                         CardLearningStatus.SUSPENDED -> error("SUSPENDED status is not supported")
                     }
-                    result[i].reviewCount shouldBe states[i].totalReviews
+                    item.reviewCount shouldBe state.totalReviews
                 }
             }
 
@@ -122,7 +131,11 @@ class DeckBFFServiceUnitTest :
                 it("덱에 카드가 없으면 빈 리스트를 반환하고 study/preset API를 호출하지 않는다") {
                     every { cardApi.getCardContentsByDeck(userId = userId, deckId = deckId) } returns emptyList()
 
-                    val result = service.getCardsWithLearningState(userId, deckId)
+                    val result = service.getCardsWithLearningState(
+                        userId = userId,
+                        deckId = deckId,
+                        sortType = CardSortType.CREATED,
+                    )
 
                     result.shouldBeEmpty()
                     verify(exactly = 0) { studyApi.getLearningStates(any(), any()) }
@@ -140,12 +153,17 @@ class DeckBFFServiceUnitTest :
                     states = states,
                 )
 
-                val result = service.getCardsWithLearningState(userId, deckId)
+                val result = service.getCardsWithLearningState(
+                    userId = userId,
+                    deckId = deckId,
+                    sortType = CardSortType.CREATED,
+                )
 
-                result[0].badge shouldBe CardLearningStateBadge.REVIEW
-                result[0].reviewCount shouldBe states.first().totalReviews
-                result[1].badge shouldBe CardLearningStateBadge.NEW
-                result[1].reviewCount shouldBe 0
+                // CREATED 정렬(cardId 역순): [2L(state 없음), 1L]
+                result[0].badge shouldBe CardLearningStateBadge.NEW
+                result[0].reviewCount shouldBe 0
+                result[1].badge shouldBe CardLearningStateBadge.REVIEW
+                result[1].reviewCount shouldBe states.first().totalReviews
             }
 
             context("badge 매핑 확인") {
@@ -178,7 +196,7 @@ class DeckBFFServiceUnitTest :
                         hardBadgeThreshold = threshold,
                     )
 
-                    val result = service.getCardsWithLearningState(userId, deckId)
+                    val result = service.getCardsWithLearningState(userId, deckId, CardSortType.CREATED)
 
                     result.first().badge shouldBe expected
                 }
@@ -193,7 +211,7 @@ class DeckBFFServiceUnitTest :
                     )
 
                     shouldThrow<IllegalStateException> {
-                        service.getCardsWithLearningState(userId, deckId)
+                        service.getCardsWithLearningState(userId, deckId, CardSortType.CREATED)
                     }
                 }
             }

--- a/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/DeckBFFServiceUnitTest.kt
@@ -166,6 +166,26 @@ class DeckBFFServiceUnitTest :
                 result[1].reviewCount shouldBe states.first().totalReviews
             }
 
+            context("정렬 적용") {
+                it("sortType의 정렬 기준이 적용된 순서로 반환한다") {
+                    val cards = (1L..3L).map { i -> createCardContent(i) }
+                    val states = listOf(
+                        createCls(cardId = 1L, status = CardLearningStatus.REVIEW, totalReviews = 1, lastReviewedDate = LocalDate.parse("2026-07-10")),
+                        createCls(cardId = 2L, status = CardLearningStatus.REVIEW, totalReviews = 1, lastReviewedDate = LocalDate.parse("2026-07-18")),
+                        createCls(cardId = 3L, status = CardLearningStatus.REVIEW, totalReviews = 1, lastReviewedDate = LocalDate.parse("2026-07-01")),
+                    )
+                    stubDeckInformation(cards = cards, states = states)
+
+                    val result = service.getCardsWithLearningState(
+                        userId = userId,
+                        deckId = deckId,
+                        sortType = CardSortType.LAST_REVIEWED,
+                    )
+
+                    result.map { it.cardId } shouldContainExactly listOf(2L, 1L, 3L)
+                }
+            }
+
             context("badge 매핑 확인") {
                 data class BadgeCase(
                     val againCount: Int,

--- a/src/test/kotlin/com/whatever/caro/bff/internal/StudyBFFServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/StudyBFFServiceUnitTest.kt
@@ -66,6 +66,7 @@ class StudyBFFServiceUnitTest :
                 status = CardLearningStatus.NEW,
                 totalReviews = 0,
                 consecutiveAgainCount = 0,
+                lastReviewedDate = null,
             )
 
         fun content(

--- a/src/test/kotlin/com/whatever/caro/bff/internal/web/DeckBFFControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/web/DeckBFFControllerWebMvcTest.kt
@@ -1,0 +1,118 @@
+package com.whatever.caro.bff.internal.web
+
+import com.whatever.caro.auth.AuthUser
+import com.whatever.caro.auth.internal.filter.JwtAuthenticationFilter
+import com.whatever.caro.auth.internal.filter.JwtExceptionFilter
+import com.whatever.caro.auth.internal.filter.RequestResponseLoggingFilter
+import com.whatever.caro.bff.internal.CardSortType
+import com.whatever.caro.bff.internal.DeckBFFService
+import com.whatever.caro.common.web.idempotency.IdempotencyProperties
+import com.whatever.caro.common.web.idempotency.IdempotencyRepository
+import io.kotest.core.spec.style.DescribeSpec
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.Clock
+
+@WebMvcTest(
+    controllers = [DeckBFFController::class],
+    excludeAutoConfiguration = [
+        SecurityAutoConfiguration::class,
+        SecurityFilterAutoConfiguration::class,
+        UserDetailsServiceAutoConfiguration::class,
+    ],
+)
+@AutoConfigureMockMvc(addFilters = false)
+class DeckBFFControllerWebMvcTest : DescribeSpec() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var deckBFFService: DeckBFFService
+
+    @MockitoBean
+    lateinit var clock: Clock
+
+    @MockitoBean
+    lateinit var jwtAuthenticationFilter: JwtAuthenticationFilter
+
+    @MockitoBean
+    lateinit var jwtExceptionFilter: JwtExceptionFilter
+
+    @MockitoBean
+    lateinit var requestResponseLoggingFilter: RequestResponseLoggingFilter
+
+    @MockitoBean
+    lateinit var idempotencyRepository: IdempotencyRepository
+
+    @MockitoBean
+    lateinit var idempotencyProperties: IdempotencyProperties
+
+    init {
+        beforeTest {
+            SecurityContextHolder.getContext().authentication =
+                UsernamePasswordAuthenticationToken(
+                    AuthUser(userId = 1L, jti = "test-jti", status = "ACTIVE"),
+                    null,
+                    emptyList(),
+                )
+        }
+
+        afterTest {
+            SecurityContextHolder.clearContext()
+        }
+
+        describe("GET /v2/decks/{deckId}/cards - sortType 바인딩") {
+            it("sortType을 생략하면 기본값 CREATED로 서비스에 전달한다") {
+                given(deckBFFService.getCardsWithLearningState(1L, 1L, CardSortType.CREATED))
+                    .willReturn(emptyList())
+
+                mockMvc.get("/v2/decks/1/cards").andExpect {
+                    status { isOk() }
+                }
+
+                verify(deckBFFService).getCardsWithLearningState(
+                    userId = 1L,
+                    deckId = 1L,
+                    sortType = CardSortType.CREATED,
+                )
+            }
+
+            it("요청으로 들어온 sortType=LAST_REVIEWED를 그대로 서비스에 전달한다") {
+                given(deckBFFService.getCardsWithLearningState(1L, 1L, CardSortType.LAST_REVIEWED))
+                    .willReturn(emptyList())
+
+                mockMvc.get("/v2/decks/1/cards") {
+                    param("sortType", "LAST_REVIEWED")
+                }.andExpect {
+                    status { isOk() }
+                }
+
+                verify(deckBFFService).getCardsWithLearningState(
+                    userId = 1L,
+                    deckId = 1L,
+                    sortType = CardSortType.LAST_REVIEWED,
+                )
+            }
+
+            it("유효하지 않은 sortType이면 400을 반환한다") {
+                mockMvc.get("/v2/decks/1/cards") {
+                    param("sortType", "INVALID")
+                }.andExpect {
+                    status { isBadRequest() }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
@@ -279,13 +279,15 @@ class StudyServiceTest(
         it("다른 유저나, 덱에 속한 세션은 결과에 영향을 주지 않는다") {
             every { deckPresetApi.getLatestDeckPresetByUser(any(), any()) } returns
                 Sm2ParamsFixture.DECK_PRESET_DTO_FIXTURE.copy(newPerDay = 0, reviewPerDay = 0)
-            createSession( // 다른 user의 오늘 ACTIVE 세션
+            createSession(
+                // 다른 user의 오늘 ACTIVE 세션
                 userId = 2L,
                 deckId = DECK_ID,
                 status = StudySessionStatus.ACTIVE,
                 startedAt = baseNow,
             )
-            createSession( // 다른 deck의 오늘 ACTIVE 세션
+            createSession(
+                // 다른 deck의 오늘 ACTIVE 세션
                 userId = USER_ID,
                 deckId = 2L,
                 status = StudySessionStatus.ACTIVE,
@@ -564,6 +566,7 @@ class StudyServiceTest(
                     cardId = 1L,
                     totalReviews = 3,
                     consecutiveAgainCount = 1,
+                    lastReviewedDate = baseDate,
                 ),
                 createCls(
                     cardId = 2L,
@@ -583,6 +586,7 @@ class StudyServiceTest(
             val firstId = cardIds.first()
             result[firstId]?.totalReviews shouldBe 3
             result[firstId]?.consecutiveAgainCount shouldBe 1
+            result[firstId]?.lastReviewedDate shouldBe baseDate
 
             val secondId = cardIds.last()
             result[secondId]?.totalReviews shouldBe 0


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
- `GET /v2/decks/{deckId}/cards` 에 `sortType` 쿼리 파라미터를 추가
  - `CREATED`, `LAST_REVIEWED`, `REVIEW_FREQUENCY`
  - 기본값은 CREATED로, 쿼리 파라미터 없이 호출하는 클라이언트는 영향 없습니다
- 정렬 규칙은 다음과 같습니다
  - CREATED: 최신 생성순(card id 역순)
  - LAST_REVIEWED: 최근 학습일 역순, 한 번도 학습하지 않은 카드는 목록 끝에 생성순으로 배치
  - REVIEW_FREQUENCY: 학습 횟수 역순
  - 정렬 기준이 동률일 경우 card id 역순으로 처리
- 애플리케이션에서 정렬을 진행한 이유
  - 정렬 대상이 서로 닫른 모듈에 걸쳐있었습니다(CREATED는 card, 나머지는 study)
  - 아직 pagenation이 mvp에 없어 어차피 덱 전체를 반환해야했습니다
  - 이런 상황에서 당장 DB로 정렬을 내릴 필요가 없다고 판단했tmqlsek

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
created_at 필드가 존재하긴 하지만, card id가 생성 순서와 동일하고 완전히 결정적이라 사용했습니다. 또 추후 페이징 시 인덱스 재활용에도 용이할거라고 생각했어요~