### PR TITLE
[Feat] streak 조회 응답에 연속학습 상태 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakService.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakService.kt
@@ -63,16 +63,16 @@ class StreakService(
         now: Instant,
         timezone: ZoneId,
         dayCutoffHour: Int,
-    ): Int {
+    ): StreakStatusResult {
         val streakState = streakStateRepository.findByUserId(userId = userId)
-            ?: return 0
+            ?: return StreakStatusResult.NotStarted
 
         val currentDate = toStreakDate(now, timezone, dayCutoffHour)
         if (isStreakAlive(streakState.lastRecordedDate, currentDate)) {
-            return streakState.currentStreak
+            return StreakStatusResult.Active(currentStreak = streakState.currentStreak)
         }
 
-        return 0
+        return StreakStatusResult.Broken
     }
 
     /**

--- a/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakStatusResult.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/streak/StreakStatusResult.kt
@@ -1,0 +1,9 @@
+package com.whatever.caro.study.internal.streak
+
+sealed interface StreakStatusResult {
+    data object NotStarted : StreakStatusResult
+    data class Active(
+        val currentStreak: Int,
+    ) : StreakStatusResult
+    data object Broken : StreakStatusResult
+}

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
@@ -3,7 +3,9 @@ package com.whatever.caro.study.internal.web
 import com.whatever.caro.auth.SecurityUtil
 import com.whatever.caro.common.response.ApiResponse
 import com.whatever.caro.study.internal.streak.StreakService
+import com.whatever.caro.study.internal.streak.StreakStatusResult
 import com.whatever.caro.study.internal.web.response.StreakResponse
+import com.whatever.caro.study.internal.web.response.StreakStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
@@ -33,13 +35,30 @@ class StreakController(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
     ): ResponseEntity<ApiResponse<StreakResponse>> {
         val now = Instant.now(clock)
-        val currentStreak = streakService.getStreak(
+        val streakStatus = streakService.getStreak(
             userId = SecurityUtil.currentUser().userId,
             now = now,
             timezone = timezone,
             dayCutoffHour = 0,
         )
-        return ResponseEntity.ok(ApiResponse.ok(StreakResponse(currentStreak = currentStreak)))
+
+        val response = when (streakStatus) {
+            is StreakStatusResult.Active -> StreakResponse(
+                status = StreakStatus.ACTIVE,
+                currentStreak = streakStatus.currentStreak,
+            )
+
+            StreakStatusResult.NotStarted -> StreakResponse(
+                status = StreakStatus.NOT_STARTED,
+                currentStreak = 0,
+            )
+
+            StreakStatusResult.Broken -> StreakResponse(
+                status = StreakStatus.BROKEN,
+                currentStreak = 0,
+            )
+        }
+        return ResponseEntity.ok(ApiResponse.ok(response))
     }
 
     @Operation(

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/response/StreakResponse.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/response/StreakResponse.kt
@@ -4,6 +4,22 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "연속 학습(streak) 응답")
 data class StreakResponse(
-    @get:Schema(description = "오늘 기준 현재 연속 학습일 수", example = "5")
+    @get:Schema(description = "연속 학습 상태")
+    val status: StreakStatus,
+    @get:Schema(description = "오늘 기준 현재 연속 학습일 수, status가 ACTIVE가 아니면 항상 0이다", example = "5")
     val currentStreak: Int,
 )
+
+@Schema(
+    description = """
+    연속 학습 상태
+    - NOT_STARTED: 학습 이력이 전혀 없음, currentStreak은 항상 0
+    - ACTIVE: streak이 유지되는 중. 오늘 아직 학습하지 않았어도 어제까지 이어졌다면 유지됨, currentStreak은 현재 연속 일수
+    - BROKEN: 이어지던 streak이 끊긴 상태, 다시 학습을 완료하면 1일차부터 시작함, currentStreak은 항상 0
+    """,
+)
+enum class StreakStatus {
+    NOT_STARTED,
+    ACTIVE,
+    BROKEN,
+}

--- a/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
@@ -6,6 +6,7 @@ import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.verify
@@ -298,17 +299,17 @@ class StreakServiceTest(
     }
 
     describe("getStreak") {
-        it("학습 이력이 없으면 0을 반환한다") {
+        it("학습 이력이 없으면 `NotStarted`을 반환한다") {
             val result = streakService.getStreak(
                 userId = USER_ID,
                 now = instantOn(d16),
                 timezone = kst,
                 dayCutoffHour = 0,
             )
-            result shouldBe 0
+            result shouldBe StreakStatusResult.NotStarted
         }
 
-        it("오늘이 마지막 기록일이면 저장된 streak을 반환한다") {
+        it("오늘이 마지막 기록일이면 저장된 streak이 포함된 `Active`를 반환한다") {
             streakService.recordStudied(userId = USER_ID, studyDate = d15)
             streakService.recordStudied(userId = USER_ID, studyDate = d16)
 
@@ -318,10 +319,12 @@ class StreakServiceTest(
                 timezone = kst,
                 dayCutoffHour = 0,
             )
-            result shouldBe 2
+
+            result.shouldBeTypeOf<StreakStatusResult.Active>()
+            result.currentStreak shouldBe 2
         }
 
-        it("마지막 기록일이 어제이면 streak이 깨지지 않았으므로 저장된 streak을 반환한다") {
+        it("마지막 기록일이 어제이면 streak이 깨지지 않았으므로 저장된 streak이 포함된 `Active`를 반환한다") {
             streakService.recordStudied(userId = USER_ID, studyDate = d15)
             streakService.recordStudied(userId = USER_ID, studyDate = d16)
 
@@ -331,10 +334,12 @@ class StreakServiceTest(
                 timezone = kst,
                 dayCutoffHour = 0,
             )
-            result shouldBe 2
+
+            result.shouldBeTypeOf<StreakStatusResult.Active>()
+            result.currentStreak shouldBe 2
         }
 
-        it("마지막 기록일로부터 이틀 이상 지나면 0을 반환한다") {
+        it("마지막 기록일로부터 이틀 이상 지나면 `Broken`을 반환한다") {
             streakService.recordStudied(userId = USER_ID, studyDate = d15)
             streakService.recordStudied(userId = USER_ID, studyDate = d16)
 
@@ -344,10 +349,10 @@ class StreakServiceTest(
                 timezone = kst,
                 dayCutoffHour = 0,
             )
-            result shouldBe 0
+            result shouldBe StreakStatusResult.Broken
         }
 
-        it("오늘이 마지막 기록보다 과거여도 streak이 살아있는 것으로 보고 저장된 streak을 반환한다") {
+        it("오늘이 마지막 기록보다 과거여도 streak이 살아있는 것으로 보고 저장된 streak이 포함된 `Active`를 반환한다") {
             streakService.recordStudied(userId = USER_ID, studyDate = d15)
             streakService.recordStudied(userId = USER_ID, studyDate = d16)
 
@@ -358,7 +363,9 @@ class StreakServiceTest(
                 timezone = kst,
                 dayCutoffHour = 0,
             )
-            result shouldBe 2
+
+            result.shouldBeTypeOf<StreakStatusResult.Active>()
+            result.currentStreak shouldBe 2
         }
 
         it("끊긴 상태를 조회해도 저장된 current_streak을 변경하지 않는다") {
@@ -372,7 +379,7 @@ class StreakServiceTest(
                 dayCutoffHour = 0,
             )
 
-            result shouldBe 0
+            result shouldBe StreakStatusResult.Broken
             val streakState = streakStateRepository.findByUserId(userId = USER_ID)!!
             streakState.currentStreak shouldBe 2
         }
@@ -388,7 +395,8 @@ class StreakServiceTest(
                 timezone = kst,
                 dayCutoffHour = 4,
             )
-            result shouldBe 2
+            result.shouldBeTypeOf<StreakStatusResult.Active>()
+            result.currentStreak shouldBe 2
         }
 
         it("같은 시간에 요청을 보내도 timezone에 따라 날짜가 변경된다면 streak 판정이 바뀐다") {
@@ -403,7 +411,8 @@ class StreakServiceTest(
                 timezone = ZoneOffset.ofHours(-12),
                 dayCutoffHour = 0,
             )
-            result1 shouldBe 2 // 클라이언트는 날짜는 16일이므로 streak이 이어짐
+            result1.shouldBeTypeOf<StreakStatusResult.Active>()
+            result1.currentStreak shouldBe 2 // 클라이언트는 날짜는 16일이므로 streak이 이어짐
 
             // UTC+14 → 오늘 d18
             val result2 = streakService.getStreak(
@@ -412,7 +421,7 @@ class StreakServiceTest(
                 timezone = ZoneOffset.ofHours(14),
                 dayCutoffHour = 0,
             )
-            result2 shouldBe 0 // 클라이언트 날짜는 18일이므로 streak이 끊김
+            result2 shouldBe StreakStatusResult.Broken // 클라이언트 날짜는 18일이므로 streak이 끊김
         }
     }
 


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
- `GET /v1/streaks` 응답에 연속학습 상태(`status`)를 추가
  - `NOT_STARTED`: 학습 이력이 전혀 없음
  - `ACTIVE`: streak 유지 중 (오늘 아직 학습 전이어도 어제까지 이어졌으면 유지, `currentStreak` = n일차)
  - `BROKEN`: 이어지던 streak이 끊김
- 도메인 결과와 응답 enum을 분리하기 위해, `StreakService.getStreak`이 `Int` 대신 sealed `StreakStatusResult`를 반환


## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)