### PR TITLE
[Feat] 릴리즈 버저닝, 이미지 발행 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Check code format
         run: ./gradlew spotlessCheck
@@ -57,16 +57,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run tests with coverage
         run: ./gradlew test koverXmlReport koverVerify
@@ -77,7 +77,7 @@ jobs:
 
       - name: Add coverage report to PR
         if: github.event_name == 'pull_request'
-        uses: mi-kas/kover-report@v1
+        uses: mi-kas/kover-report@v2
         with:
           path: build/reports/kover/report.xml
           title: Code Coverage Report
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-reports
           path: |
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload test failure reports
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: build/reports/tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/whatever-x/caro-backend
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify Tag & Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check tag commit
+        run: |
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/develop \
+          || { echo "::error::태그 커밋이 히스토리에 없습니다"; exit 1; }
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run tests
+        run: ./gradlew test koverVerify
+
+  build-push:
+    name: Build & Push Image
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Login to ghcr
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value={{date 'YYYY-MM-DD'}},enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Compute build args
+        id: vars
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Assert `metadata version == tag`
+        run: |
+          test "${{ steps.meta.outputs.version }}" = "${GITHUB_REF_NAME#v}" \
+          || { echo "::error::metadata version과 태그가 불일치"; exit 1; }
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
+
+      - name: Fail if image tag already exists
+        run: |
+          if docker buildx imagetools inspect "$IMAGE_NAME:${{ steps.meta.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::${{ steps.meta.outputs.version }} 태그가 이미 존재합니다"; exit 1;
+          fi
+
+      - name: Build & Push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            RELEASE_VERSION=${{ steps.meta.outputs.version }}
+            GIT_COMMIT=${{ steps.vars.outputs.short_sha }}
+            BUILD_TIME=${{ steps.vars.outputs.build_time }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,15 @@ COPY gradlew settings.gradle.kts build.gradle.kts ./
 COPY gradle ./gradle
 RUN chmod +x ./gradlew
 
+ARG RELEASE_VERSION=0.0.1-SNAPSHOT
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+
 COPY src ./src
 RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon bootJar -x test \
- && mv build/libs/caro-*-SNAPSHOT.jar build/libs/app.jar
+    -Pversion=$RELEASE_VERSION -PgitCommit=$GIT_COMMIT -PbuildTime=$BUILD_TIME \
+ && grep -q "^build.version=$RELEASE_VERSION$" build/resources/main/META-INF/build-info.properties
 
 RUN java -Djarmode=tools -jar build/libs/app.jar \
         extract --layers --destination application

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,6 +198,22 @@ kover {
     }
 }
 
+springBoot {
+    buildInfo {
+        // actuator에 노출하기 위한 META-INF/build-info.properties 생성
+        excludes.add("time")
+        properties {
+            additional.put("commit", providers.gradleProperty("gitCommit").orElse("unknown"))
+            // 빌드 시점마다 가변적인 time 대신, 명시적인 값을 주입받아 사용
+            additional.put("buildTime", providers.gradleProperty("buildTime").orElse("unknown"))
+        }
+    }
+}
+
+tasks.bootJar {
+    archiveFileName = "app.jar" // entrypoint.sh에서 app.jar를 사용하므로 fix
+}
+
 // check 태스크에 연결
 tasks.named("check") {
     dependsOn("spotlessCheck")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,4 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 rootProject.name = "caro"

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -10,6 +10,7 @@ spring:
   flyway:
     clean-disabled: true
     locations: classpath:db/migration,classpath:db/seed-prod
+    ignore-migration-patterns: "*:missing"
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -7,6 +7,7 @@ spring:
   flyway:
     clean-disabled: true
     locations: classpath:db/migration,classpath:db/seed-dev
+    ignore-migration-patterns: "*:missing"
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
- 배포한 컨테이너가 어떤 코드인지 파악하고 롤백할 수 있도록 버저닝을 추가했고, 이미지 발행 워크플로우를 추가했습니다.
  - 이미지를 생성 후 GHCR에 push까지 진행하고, 배포는 미포함
- git tag push를 트리거로, 테스트 재실행 -> 이미지 빌드 -> GHCR push 순서로 진행됩니다.
- 이미지에는 `v1.2.3` → `1.2.3` / `1.2` / `1` / `latest` / `sha-<short>` / `2026-07-26` 태그가 붙습니다.
  - 만약 사전 릴리즈를 진행할 경우 `v1.2.3-rc.1`와 같이 푸시할 경우, `latest`와 날짜, 버전 계층 태그는 생성하지 않습니다.

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
아지거 action 동작을 검증하지 않았습니다. dev branch에 병합 후 확인 예정입니다.