### PR TITLE
[Feat] ci workflow에 docker image build 확인 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,10 @@ jobs:
           cache-from: type=gha
           cache-to: type-gha,mode=max
 
-  notify-main-failure:
-    name: Notify Main Failure
+  notify-ci-failure:
+    name: Notify CI Failure
     needs: [ format-check, test, docker-build-check ]
-    if: failure() && github.ref == 'refs/heads/main'
+    if: failure() && github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -154,16 +154,16 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_GIT_NOTIFY_CHANNEL_ID }}
-            text: "main 브랜치 CI 실패"
+            text: "${{ github.ref_name }} 브랜치 CI 실패"
             blocks:
               - type: header
                 text:
                   type: plain_text
-                  text: "Production 배포 차단"
+                  text: "${{ github.ref_name }} 브랜치 CI 실패"
               - type: section
                 text:
                   type: mrkdwn
-                  text: "<!channel> *main* 브랜치 CI 실패"
+                  text: "<!channel> *${{ github.ref_name }}* 브랜치 CI 실패"
               - type: section
                 fields:
                   - type: mrkdwn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           context: .
           push: false
           cache-from: type=gha
-          cache-to: type-gha,mode=max
+          cache-to: type=gha,mode=max
 
   notify-ci-failure:
     name: Notify CI Failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           context: .
           push: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max' || '' }}  # PR merge시에만 cache write
 
   notify-ci-failure:
     name: Notify CI Failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,29 @@ jobs:
           path: build/reports/tests/
           retention-days: 7
 
+  docker-build-check:
+    name: Docker build check
+    needs: [ format-check, test ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type-gha,mode=max
+
   notify-main-failure:
     name: Notify Main Failure
-    needs: [ format-check, test ]
+    needs: [ format-check, test, docker-build-check ]
     if: failure() && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,4 +112,3 @@ jobs:
             GIT_COMMIT=${{ steps.vars.outputs.short_sha }}
             BUILD_TIME=${{ steps.vars.outputs.build_time }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: |
             RELEASE_VERSION=${{ steps.meta.outputs.version }}
             GIT_COMMIT=${{ steps.vars.outputs.short_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags: [ 'v*' ]
 
 concurrency:
   group: release-${{ github.ref }}
@@ -106,6 +106,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             RELEASE_VERSION=${{ steps.meta.outputs.version }}
             GIT_COMMIT=${{ steps.vars.outputs.short_sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
 # ===== Build stage =====
 FROM eclipse-temurin:25-jdk AS builder
 WORKDIR /workspace
+ENV GRADLE_USER_HOME=/workspace/.gradlehome
 
 # Cache dependencies first
 COPY gradlew settings.gradle.kts build.gradle.kts ./
 COPY gradle ./gradle
+COPY docker/resolve-deps.init.gradle.kts ./
 RUN chmod +x ./gradlew
+
+RUN ./gradlew --no-daemon \
+    -I /workspace/resolve-deps.init.gradle.kts resolveAllDependencies
 
 ARG RELEASE_VERSION=0.0.1-SNAPSHOT
 ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
 
 COPY src ./src
-RUN --mount=type=cache,target=/root/.gradle \
-    ./gradlew --no-daemon bootJar -x test \
+RUN ./gradlew --no-daemon bootJar -x test \
     -Pversion=$RELEASE_VERSION -PgitCommit=$GIT_COMMIT -PbuildTime=$BUILD_TIME \
  && grep -q "^build.version=$RELEASE_VERSION$" build/resources/main/META-INF/build-info.properties
 

--- a/docker/resolve-deps.init.gradle.kts
+++ b/docker/resolve-deps.init.gradle.kts
@@ -1,0 +1,15 @@
+allprojects {
+    tasks.register("resolveAllDependencies") {
+        doLast {
+            configurations
+                .filter { it.isCanBeResolved }
+                .forEach { conf ->
+                    try {
+                        conf.resolve()
+                    } catch (e: Exception) {
+                        logger.lifecycle("SKIP ${conf.name}: ${e.message}")
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
### CI에 docker build 검증 추가
- `docker-build-check` job 추가되었고, push는 진행하지 않습니다

### 빌드 캐시 조정
검증 job에서 매번 콜드 빌드를 진행하면 비효율적이어서 캐시 구조를 수정했습니다.
- Dockerfile에서 `--mount=type=cache`를 제거
  - 해당 cache mount는 Github Action cache로 export되지 않아서 로컬 환경에서만 유효하고, Actions worker에서는 매번 의존성을 새로 받고있었습니다.
  - 의존성을 사전에 resolve하고 해당 레이어를 `COPY src` 앞에 배치하여 소스코드가 변경되어도 의존성 레이어의 캐시는 유지되도록 했습니다.

### Cache write 시점 조정
Github Actions 캐시는 ref 단위로 격리되고, A ref에서 쓴 캐시는 B ref에서 읽을 수 없습니다.
- `release.yml`의 `cache-to`옵션을 제거
  - tag를 push해서 트리거되므로, tag ref에서 write된 캐시는 재사용되지 못해 용량만 차지
  - default branch는 다른 ref에서도 참고 가능하므로 cache-from은 유지

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)