### PR TITLE
[Fix] Ci workflow 테스트 job 실행 시 발생하는 OOM 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -223,28 +223,9 @@ tasks.withType<Test> {
     useJUnitPlatform()
     systemProperty("user.timezone", "UTC")
 
-//    // ===== OOM 재현 실습용 임시 설정 시작 (실습 후 제거 또는 영구안으로 교체) =====
-//    // 사용: ./gradlew test --rerun -PtestHeap=256m
-//    // -PtestHeap 미지정 시 512m = Gradle 기본값이자 CI에서 터진 조건
-//    maxHeapSize = (findProperty("testHeap") as String?) ?: "512m"
-//
-//    val oomReportDir = layout.buildDirectory.dir("reports/oom-repro").get().asFile
-//    doFirst { oomReportDir.mkdirs() }
-//
-//    jvmArgs(
-//        "-XX:+HeapDumpOnOutOfMemoryError",
-//        "-XX:HeapDumpPath=${oomReportDir.absolutePath}",
-//        "-Xlog:gc*:file=${oomReportDir.absolutePath}/gc.log:time,uptime,level,tags",
-//    )
-//
-//    // Spring 컨텍스트 캐시 통계(size / hitCount / missCount)를 남긴다
-//    systemProperty("logging.level.org.springframework.test.context.cache", "DEBUG")
-//
-//    testLogging {
-//        events("failed")
-//        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-//        showStackTraces = true
-//        showCauses = true
-//    }
-//    // ===== 임시 설정 끝 =====
+    maxHeapSize = "1g"
+    jvmArgs(
+        "-XX:+ExitOnOutOfMemoryError",
+        "-Xlog:gc*:file=build/test-gc.log:time,uptime",
+    )
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -222,4 +222,29 @@ tasks.named("check") {
 tasks.withType<Test> {
     useJUnitPlatform()
     systemProperty("user.timezone", "UTC")
+
+//    // ===== OOM 재현 실습용 임시 설정 시작 (실습 후 제거 또는 영구안으로 교체) =====
+//    // 사용: ./gradlew test --rerun -PtestHeap=256m
+//    // -PtestHeap 미지정 시 512m = Gradle 기본값이자 CI에서 터진 조건
+//    maxHeapSize = (findProperty("testHeap") as String?) ?: "512m"
+//
+//    val oomReportDir = layout.buildDirectory.dir("reports/oom-repro").get().asFile
+//    doFirst { oomReportDir.mkdirs() }
+//
+//    jvmArgs(
+//        "-XX:+HeapDumpOnOutOfMemoryError",
+//        "-XX:HeapDumpPath=${oomReportDir.absolutePath}",
+//        "-Xlog:gc*:file=${oomReportDir.absolutePath}/gc.log:time,uptime,level,tags",
+//    )
+//
+//    // Spring 컨텍스트 캐시 통계(size / hitCount / missCount)를 남긴다
+//    systemProperty("logging.level.org.springframework.test.context.cache", "DEBUG")
+//
+//    testLogging {
+//        events("failed")
+//        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+//        showStackTraces = true
+//        showCauses = true
+//    }
+//    // ===== 임시 설정 끝 =====
 }

--- a/src/test/kotlin/com/whatever/caro/CaroApplicationTests.kt
+++ b/src/test/kotlin/com/whatever/caro/CaroApplicationTests.kt
@@ -2,10 +2,19 @@ package com.whatever.caro
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.context.annotation.Import
 
+/**
+ * 전체 애플리케이션 컨텍스트 테스트
+ *
+ * @AutoConfigureMockMvc는 이 테스트에서 사용하지 않지만,
+ * PublicEndpointsOpenApiConsistencyTest 와 동일한 TestContext 캐시 키를 만들어
+ * 전체 앱 컨텍스트가 중복으로 뜨는 것을 막기 위해 유지
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
 @Import(TestcontainersConfiguration::class)
-@SpringBootTest
 class CaroApplicationTests {
 
     @Test

--- a/src/test/kotlin/com/whatever/caro/CaroApplicationTests.kt
+++ b/src/test/kotlin/com/whatever/caro/CaroApplicationTests.kt
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Import
  * PublicEndpointsOpenApiConsistencyTest 와 동일한 TestContext 캐시 키를 만들어
  * 전체 앱 컨텍스트가 중복으로 뜨는 것을 막기 위해 유지
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest
 @AutoConfigureMockMvc
 @Import(TestcontainersConfiguration::class)
 class CaroApplicationTests {

--- a/src/test/kotlin/com/whatever/caro/CaroModuleTest.kt
+++ b/src/test/kotlin/com/whatever/caro/CaroModuleTest.kt
@@ -1,0 +1,22 @@
+package com.whatever.caro
+
+import org.springframework.context.annotation.Import
+import org.springframework.core.annotation.AliasFor
+import org.springframework.modulith.test.ApplicationModuleTest
+
+/**
+ * 모듈 통합 테스트 공통 어노테이션
+ *
+ * @Import(TestcontainersConfiguration)을 고정해 설정 누락으로 인한 컨텍스트가 늘어나는 것을 방지.
+ * extraIncludes 조합이 다를 경우 컨텍스트는 통일되지 않음.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ApplicationModuleTest
+@Import(TestcontainersConfiguration::class)
+annotation class CaroModuleTest(
+    @get:AliasFor(annotation = ApplicationModuleTest::class, attribute = "mode")
+    val mode: ApplicationModuleTest.BootstrapMode = ApplicationModuleTest.BootstrapMode.STANDALONE,
+    @get:AliasFor(annotation = ApplicationModuleTest::class, attribute = "extraIncludes")
+    val extraIncludes: Array<String> = [],
+)

--- a/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/AuthServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.auth.internal
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.auth.AuthUser
 import com.whatever.caro.auth.exception.InvalidRefreshTokenException
 import com.whatever.caro.auth.exception.InvalidSocialTokenException
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Duration
 
 private const val TEST_ID_TOKEN = "test-id-token"
@@ -49,8 +48,8 @@ class MockSocialVerifierConfig {
     fun socialIdTokenVerifierFactory(): SocialIdTokenVerifierFactory = mockk(relaxed = true)
 }
 
-@ApplicationModuleTest(extraIncludes = ["common", "user"])
-@Import(TestcontainersConfiguration::class, MockSocialVerifierConfig::class)
+@CaroModuleTest(extraIncludes = ["common", "user"])
+@Import(MockSocialVerifierConfig::class)
 class AuthServiceTest(
     private val authService: AuthService,
     private val socialIdTokenVerifierFactory: SocialIdTokenVerifierFactory,

--- a/src/test/kotlin/com/whatever/caro/auth/internal/social/AppleIdTokenVerifierTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/social/AppleIdTokenVerifierTest.kt
@@ -8,7 +8,7 @@ import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.auth.exception.InvalidSocialTokenException
 import com.whatever.caro.auth.internal.config.OAuth2Properties
 import com.whatever.caro.user.SocialProvider
@@ -16,11 +16,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.modulith.test.ApplicationModuleTest
 import org.springframework.test.web.client.MockRestServiceServer
 import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
@@ -37,8 +35,7 @@ private const val DEFAULT_PROVIDER_USER_ID = "000851.test-user-id.0747"
 
 private const val APPLE_PROVIDER = "apple"
 
-@ApplicationModuleTest(extraIncludes = ["common", "user"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common", "user"])
 class AppleIdTokenVerifierTest(
     private val oidcPublicKeyCacheRepository: OidcPublicKeyCacheRepository,
     private val redisTemplate: StringRedisTemplate,

--- a/src/test/kotlin/com/whatever/caro/auth/internal/social/OidcPublicKeyCacheRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/social/OidcPublicKeyCacheRepositoryTest.kt
@@ -1,20 +1,17 @@
 package com.whatever.caro.auth.internal.social
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.comparables.shouldBeBetween
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
 import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-@ApplicationModuleTest(extraIncludes = ["common", "user"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common", "user"])
 class OidcPublicKeyCacheRepositoryTest(
     private val oidcPublicKeyCacheRepository: OidcPublicKeyCacheRepository,
     private val redisTemplate: StringRedisTemplate,

--- a/src/test/kotlin/com/whatever/caro/auth/internal/token/RefreshTokenRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/token/RefreshTokenRepositoryTest.kt
@@ -1,20 +1,17 @@
 package com.whatever.caro.auth.internal.token
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.comparables.shouldBeBetween
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
 import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-@ApplicationModuleTest(extraIncludes = ["common", "user"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common", "user"])
 class RefreshTokenRepositoryTest(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val redisTemplate: StringRedisTemplate,

--- a/src/test/kotlin/com/whatever/caro/auth/internal/token/TokenBlacklistRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/auth/internal/token/TokenBlacklistRepositoryTest.kt
@@ -1,16 +1,13 @@
 package com.whatever.caro.auth.internal.token
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
-import org.springframework.context.annotation.Import
 import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Duration
 
-@ApplicationModuleTest(extraIncludes = ["common", "user"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common", "user"])
 class TokenBlacklistRepositoryTest(
     private val tokenBlacklistRepository: TokenBlacklistRepository,
     private val redisTemplate: StringRedisTemplate,

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/DeckRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/DeckRepositoryTest.kt
@@ -1,20 +1,17 @@
 package com.whatever.caro.card.internal.deck
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
-import org.springframework.modulith.test.ApplicationModuleTest
 import org.springframework.transaction.annotation.Transactional
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common"])
 @Transactional
 class DeckRepositoryTest(
     private val deckRepository: DeckRepository,
 ) : DescribeSpec({
 
-    afterEach { deckRepository.deleteAllInBatch() }
+    afterTest { deckRepository.deleteAllInBatch() }
 
     fun saveDeck(
         cardCount: Int,

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckPresetServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.card.internal.deck.service
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.card.internal.deck.Deck
 import com.whatever.caro.card.internal.deck.DeckPreset
 import com.whatever.caro.card.internal.deck.DeckPresetRepository
@@ -12,12 +12,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common"])
 class DeckPresetServiceTest(
     private val deckPresetService: DeckPresetService,
     private val deckRepository: DeckRepository,

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/service/DeckServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.card.internal.deck.service
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.card.internal.deck.Deck
 import com.whatever.caro.card.internal.deck.DeckRepository
 import com.whatever.caro.card.internal.deck.dto.create.CreateDeckDto
@@ -13,11 +13,8 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
-import org.springframework.modulith.test.ApplicationModuleTest
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common"])
 class DeckServiceTest(
     private val deckService: DeckService,
     private val deckRepository: DeckRepository,

--- a/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/common/web/idempotency/IdempotencyRepositoryTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.common.web.idempotency
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -9,14 +9,11 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.ranges.shouldBeIn
 import io.kotest.matchers.shouldBe
 import org.awaitility.Awaitility.await
-import org.springframework.context.annotation.Import
 import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
-@ApplicationModuleTest
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest
 class IdempotencyRepositoryTest(
     private val repository: IdempotencyRepository,
     private val redisTemplate: StringRedisTemplate,

--- a/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/EvaluationServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.Rating
@@ -33,7 +33,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -54,8 +53,8 @@ class MockDeckPresetApiConfig {
     fun restDayCheckService(): RestDayCheckService = mockk(relaxed = true)
 }
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class EvaluationServiceTest(
     private val evaluationService: EvaluationService,
     private val deckPresetApi: DeckPresetApi,

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceOnCardDeletionTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceOnCardDeletionTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
@@ -12,7 +12,6 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -20,8 +19,8 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class StudyServiceOnCardDeletionTest(
     private val studyService: StudyService,
     private val studySessionRepository: StudySessionRepository,

--- a/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/StudyServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.card.api.deck.DeckPresetApi
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.StudySessionStatus
@@ -26,15 +26,14 @@ import io.mockk.every
 import io.mockk.verify
 import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class StudyServiceTest(
     private val studyService: StudyService,
     private val studySessionRepository: StudySessionRepository,

--- a/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/cardlearningstate/CardLearningStateRepositoryTest.kt
@@ -1,18 +1,17 @@
 package com.whatever.caro.study.internal.cardlearningstate
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.time.LocalDate
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class CardLearningStateRepositoryTest(
     private val cardLearningStateRepository: CardLearningStateRepository,
 ) : DescribeSpec({

--- a/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/event/CardLearningStateEventListenerTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal.event
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.card.api.event.CardsDeletedEvent
 import com.whatever.caro.study.CardLearningStatus
 import com.whatever.caro.study.StudySessionStatus
@@ -19,7 +19,6 @@ import org.awaitility.Awaitility.await
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.modulith.test.ApplicationModuleTest
 import org.springframework.transaction.support.TransactionTemplate
 import java.math.BigDecimal
 import java.time.Clock
@@ -28,8 +27,8 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class CardLearningStateEventListenerTest(
     private val transactionTemplate: TransactionTemplate,
     private val publisher: ApplicationEventPublisher,

--- a/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/streak/StreakServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal.streak
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.study.StreakType
 import com.whatever.caro.study.internal.MockDeckPresetApiConfig
 import io.kotest.core.spec.style.DescribeSpec
@@ -11,14 +11,13 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.verify
 import org.springframework.context.annotation.Import
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class StreakServiceTest(
     private val streakService: StreakService,
     private val streakStateRepository: StreakStateRepository,

--- a/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
+++ b/src/test/kotlin/com/whatever/caro/study/internal/studysession/StudySessionRepositoryTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.study.internal.studysession
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.study.StudySessionStatus
 import com.whatever.caro.study.StudyType
 import com.whatever.caro.study.internal.MockDeckPresetApiConfig
@@ -8,13 +8,12 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class, MockDeckPresetApiConfig::class)
+@CaroModuleTest(extraIncludes = ["common"])
+@Import(MockDeckPresetApiConfig::class)
 class StudySessionRepositoryTest(
     private val studySessionRepository: StudySessionRepository,
 ) : DescribeSpec({

--- a/src/test/kotlin/com/whatever/caro/user/internal/UserServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/user/internal/UserServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.user.internal
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.user.SocialProvider
 import com.whatever.caro.user.UserStatus
 import com.whatever.caro.user.exception.AlreadyCompletedException
@@ -14,14 +14,11 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.modulith.test.ApplicationModuleTest
 import java.time.Instant
 import java.util.UUID
 
-@ApplicationModuleTest(extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(extraIncludes = ["common"])
 class UserServiceTest(
     private val userService: UserService,
     private val userRepository: UserRepository,

--- a/src/test/kotlin/com/whatever/caro/withdrawal/internal/WithdrawnUserPurgeServiceTest.kt
+++ b/src/test/kotlin/com/whatever/caro/withdrawal/internal/WithdrawnUserPurgeServiceTest.kt
@@ -1,6 +1,6 @@
 package com.whatever.caro.withdrawal.internal
 
-import com.whatever.caro.TestcontainersConfiguration
+import com.whatever.caro.CaroModuleTest
 import com.whatever.caro.card.internal.card.Card
 import com.whatever.caro.card.internal.card.CardRepository
 import com.whatever.caro.card.internal.deck.Deck
@@ -37,7 +37,6 @@ import com.whatever.caro.user.internal.UserRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
-import org.springframework.context.annotation.Import
 import org.springframework.modulith.test.ApplicationModuleTest
 import java.math.BigDecimal
 import java.time.Instant
@@ -49,8 +48,7 @@ import java.time.ZoneId
  * user/study/card 모듈의 실제 빈을 함께 띄워(ALL_DEPENDENCIES) 11개 테이블이 실제로 비워지는지,
  * 그리고 다른 유저 데이터/시스템 프리셋/공유 템플릿은 보존되는지 검증한다.
  */
-@ApplicationModuleTest(mode = ApplicationModuleTest.BootstrapMode.ALL_DEPENDENCIES, extraIncludes = ["common"])
-@Import(TestcontainersConfiguration::class)
+@CaroModuleTest(mode = ApplicationModuleTest.BootstrapMode.ALL_DEPENDENCIES, extraIncludes = ["common"])
 class WithdrawnUserPurgeServiceTest(
     private val purgeService: WithdrawnUserPurgeService,
     private val sweeper: WithdrawnUserPurgeSweeper,


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
### JVM Heap 상향
gradle test task 기본값으로 `-Xmx152m`로 실행되는데, Spring Context 약 15개정도가 떠있어 힙에 여유가 없었습니다.
그래서 maxHeapSize을 1g로 상향했고, GC 발생이 없는걸 로컬에서 확인 완료했습니다
  | 힙 | Full GC | 실행 시간 |
  |---|---|---|
  | 512m (기존) | 894회 | 182.5초 |
  | **1g** | **0회** | 133.4초 |

### 모듈 테스트 공통 어노테이션
- 기존에 `@ApplicationModuleTest` + `@Import(TestcontainersConfiguration)`을 테스트마다 사용했었는데, `@Import`누락 시 context가 더 뜨는 문제를 방지하기 위해 `@CaroModultTest`로 통일했습니다.
- `CaroApplicationTests`에는 `@AutoConfigureMockMvc`를 추가했습니다. `PublicEndpointsOpenApiConsistencyTest`와 동일한 Context를 사용할 수 있도록 했습니다.


## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
현재 약 14개 정도의 spring context가 뜨는데, 이 이하로 줄이는건 같이 얘기를 해봐야 할듯 싶어서 보류했습니다~