### PR TITLE
[Refactor] url 버전 prefix를 헤더 기반 버저닝으로 전환

### DIFF
--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/PublicEndpoints.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/PublicEndpoints.kt
@@ -13,8 +13,8 @@ object PublicEndpoints {
     )
 
     val AUTH = listOf(
-        "/v1/auth/social-login",
-        "/v1/auth/refresh",
+        "/auth/social-login",
+        "/auth/refresh",
     )
 
     val PATTERNS: List<String> = AUTH + MONITORING + SWAGGER

--- a/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/config/SecurityConfig.kt
@@ -50,10 +50,10 @@ class SecurityConfig(
             authorizeHttpRequests {
                 // staging 에서는 SwaggerSecurityConfig가 우선시되어 Basic Auth 필요
                 PublicEndpoints.PATTERNS.forEach { authorize(it, permitAll) }
-                authorize("/v1/auth/complete-registration", hasRole("SUSPENDED"))
-                authorize("/v1/nicknames/**", hasRole("SUSPENDED"))
-                authorize("/v1/users/nickname/**", hasRole("SUSPENDED"))
-                authorize("/v1/auth/logout", authenticated)
+                authorize("/auth/complete-registration", hasRole("SUSPENDED"))
+                authorize("/nicknames/**", hasRole("SUSPENDED"))
+                authorize("/users/nicknames/**", hasRole("SUSPENDED"))
+                authorize("/auth/logout", authenticated)
                 authorize(anyRequest, hasRole("ACTIVE"))
             }
 

--- a/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
+++ b/src/main/kotlin/com/whatever/caro/auth/internal/web/AuthController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Auth", description = "인증 / 세션 관리")
 @RestController
-@RequestMapping("/v1/auth")
+@RequestMapping("/auth")
 class AuthController(
     private val authService: AuthService,
 ) {
@@ -32,7 +32,7 @@ class AuthController(
         description = "소셜 ID 토큰을 검증해 access/refresh 토큰을 발급한다. 신규 사용자는 isRegistrationComplete=false 로 응답.",
     )
     @PublicApi
-    @PostMapping("/social-login")
+    @PostMapping("/social-login", version = "1.0")
     fun socialLogin(
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
         @RequestHeader(name = "Device-Id", required = true) deviceId: String,
@@ -46,7 +46,7 @@ class AuthController(
         summary = "회원가입 완료",
         description = "닉네임/약관 동의 입력 후 access/refresh 토큰을 재발급한다.",
     )
-    @PostMapping("/complete-registration")
+    @PostMapping("/complete-registration", version = "1.0")
     fun completeRegistration(
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
         @RequestHeader(name = "Device-Id", required = true) deviceId: String,
@@ -62,7 +62,7 @@ class AuthController(
         description = "Refresh Token 으로 access/refresh 토큰을 재발급한다. 단일 사용 정책.",
     )
     @PublicApi
-    @PostMapping("/refresh")
+    @PostMapping("/refresh", version = "1.0")
     fun refreshToken(
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
         @RequestHeader(name = "Device-Id", required = true) deviceId: String,
@@ -76,7 +76,7 @@ class AuthController(
         summary = "로그아웃",
         description = "현재 access token 을 블랙리스트 처리하고 디바이스 refresh token 을 폐기한다.",
     )
-    @PostMapping("/logout")
+    @PostMapping("/logout", version = "1.0")
     fun logout(
         @Parameter(name = "Device-Id", description = "디바이스 식별자", required = true, example = "unique-device-identifier")
         @RequestHeader(name = "Device-Id", required = true) deviceId: String,
@@ -90,7 +90,7 @@ class AuthController(
         summary = "탈퇴",
         description = "유저를 탈퇴처리 하고, 현재 access token 을 블랙리스트 처리하고 유저의 모든 refresh token 을 폐기한다.",
     )
-    @DeleteMapping("/withdraw")
+    @DeleteMapping("/withdraw", version = "1.0")
     fun withdraw(): ResponseEntity<ApiResponse<Unit>> {
         val authUser = SecurityUtil.currentUser()
         authService.withdrawUser(authUser)

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/DeckBFFController.kt
@@ -42,7 +42,7 @@ class DeckBFFController(
         - REVIEW_FREQUENCY: 복습 수(reviewCount) 많은 순
         """,
     )
-    @GetMapping("/v2/decks/{deckId}/cards")
+    @GetMapping("/decks/{deckId}/cards", version = "2.0")
     fun getCardsByDeck(
         @Parameter(description = "덱 ID", required = true) @PathVariable deckId: Long,
         @Parameter(description = "정렬 기준 (기본값 CREATED)")
@@ -67,7 +67,7 @@ class DeckBFFController(
         (NOT_STARTED는 오늘 학습 목표의 합, REST_DAY는 0)
         """,
     )
-    @GetMapping("/v1/decks")
+    @GetMapping("/decks", version = "1.0")
     fun getDecks(
         @RequestHeader("Client-Timezone", required = true) timezone: ZoneId,
     ): ResponseEntity<ApiResponse<List<DeckListResponse>>> {

--- a/src/main/kotlin/com/whatever/caro/bff/internal/web/StudyBFFController.kt
+++ b/src/main/kotlin/com/whatever/caro/bff/internal/web/StudyBFFController.kt
@@ -21,7 +21,7 @@ import java.time.ZoneId
 
 @Tag(name = "StudySession", description = "일일학습 세션 / 평가")
 @RestController
-@RequestMapping("/v1/study-sessions")
+@RequestMapping("/study-sessions")
 class StudyBFFController(
     private val clock: Clock,
     private val studyBFFService: StudyBFFService,
@@ -37,7 +37,7 @@ class StudyBFFController(
         """,
     )
     @Idempotent
-    @PostMapping("/daily")
+    @PostMapping("/daily", version = "1.0")
     fun startDailyStudy(
         @RequestHeader("Idempotency-Key", required = true) idempotencyKey: String,
         @RequestHeader("Client-Timezone", required = true) timezone: ZoneId,

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import org.springframework.http.ResponseEntity
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -34,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.ZoneId
 
 @Tag(name = "Card", description = "카드 관리")
-@Validated
 @RestController
 class CardController(
     private val cardService: CardService,

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -56,7 +56,7 @@ class CardController(
 
     @Operation(
         summary = "덱의 카드 목록 조회 (deprecated)",
-        description = "덱에 속한 카드 목록을 조회한다. 학습 상태(badge/복습 수)가 포함된 `GET /v2/decks/{deckId}/cards` 로 대체되었다.",
+        description = "덱에 속한 카드 목록을 조회한다. 학습 상태(badge/복습 수)가 포함된 `GET /decks/{deckId}/cards` 로 대체되었다.",
         deprecated = true,
     )
     @Deprecated(message = "v2 메서드로 변경 필요")

--- a/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/card/CardController.kt
@@ -43,7 +43,7 @@ class CardController(
         summary = "카드 생성",
         description = "덱에 여러 카드를 한 번에 생성한다.",
     )
-    @PostMapping("/v1/decks/{deckId}/cards")
+    @PostMapping("/decks/{deckId}/cards", version = "1.0")
     fun createCards(
         @Parameter(description = "덱 ID", required = true)
         @Positive @PathVariable deckId: Long,
@@ -60,7 +60,7 @@ class CardController(
         deprecated = true,
     )
     @Deprecated(message = "v2 메서드로 변경 필요")
-    @GetMapping("/v1/decks/{deckId}/cards")
+    @GetMapping("/decks/{deckId}/cards", version = "1.0")
     fun getCardsByDeck(
         @Parameter(description = "덱 ID", required = true)
         @Positive @PathVariable deckId: Long,
@@ -74,7 +74,7 @@ class CardController(
         summary = "카드 단건 조회",
         description = "카드 ID로 카드 1건을 조회한다.",
     )
-    @GetMapping("/v1/cards/{id}")
+    @GetMapping("/cards/{id}", version = "1.0")
     fun getCard(
         @Parameter(description = "카드 ID", required = true)
         @Positive @PathVariable id: Long,
@@ -88,7 +88,7 @@ class CardController(
         summary = "카드 수정",
         description = "카드의 필드 값을 수정한다.",
     )
-    @PatchMapping("/v1/cards/{id}")
+    @PatchMapping("/cards/{id}", version = "1.0")
     fun updateCard(
         @Parameter(description = "카드 ID", required = true)
         @Positive @PathVariable id: Long,
@@ -106,7 +106,7 @@ class CardController(
         삭제는 일일학습 목표/진행도와 streak 계산에 반영되므로 `Client-Timezone` 헤더로 사용자의 오늘 경계를 판단한다.
         """,
     )
-    @DeleteMapping("/v1/cards")
+    @DeleteMapping("/cards", version = "1.0")
     fun deleteCards(
         @RequestHeader("Client-Timezone", required = true)
         timezone: ZoneId,

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Deck", description = "단어/표현 덱 관리")
 @Validated
 @RestController
-@RequestMapping("/v1/decks")
+@RequestMapping("/decks")
 class DeckController(
     private val deckService: DeckService,
 ) {
@@ -41,7 +41,7 @@ class DeckController(
         summary = "덱 생성",
         description = "새 덱을 생성하고 기본 프리셋을 연결한다.",
     )
-    @PostMapping
+    @PostMapping(version = "1.0")
     fun createDeck(
         @Valid @RequestBody createDeckRequest: CreateDeckRequest,
     ): ResponseEntity<ApiResponse<CreateDeckResponse>> {
@@ -54,7 +54,7 @@ class DeckController(
         summary = "덱 삭제",
         description = "덱을 삭제한다. 덱에 속한 카드와 학습 상태도 함께 정리된다.",
     )
-    @DeleteMapping("/{deckId}")
+    @DeleteMapping("/{deckId}", version = "1.0")
     fun deleteDeck(
         @Parameter(description = "덱 ID", required = true)
         @Positive @PathVariable deckId: Long,
@@ -71,7 +71,7 @@ class DeckController(
         summary = "덱 수정",
         description = "덱의 이름/설명 등 메타데이터를 수정한다.",
     )
-    @PatchMapping("/{deckId}")
+    @PatchMapping("/{deckId}", version = "1.0")
     fun updateDeck(
         @Parameter(description = "덱 ID", required = true)
         @PathVariable deckId: Long,

--- a/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
+++ b/src/main/kotlin/com/whatever/caro/card/internal/deck/controller/DeckController.kt
@@ -20,7 +20,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import org.springframework.http.ResponseEntity
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,7 +29,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Deck", description = "단어/표현 덱 관리")
-@Validated
 @RestController
 @RequestMapping("/decks")
 class DeckController(

--- a/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
@@ -7,10 +7,16 @@ import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.GlobalOperationCustomizer
 import org.springdoc.core.customizers.OperationCustomizer
+import org.springdoc.core.filters.OpenApiMethodFilter
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.web.bind.annotation.RequestMapping
+import java.lang.reflect.Method
 
 @Configuration
 @Profile("!prod")
@@ -39,8 +45,8 @@ class OpenApiConfig {
             .addSecurityItem(SecurityRequirement().addList(BEARER_SCHEME_NAME))
 
     @Bean
-    fun acceptLanguageHeaderCustomizer(): OperationCustomizer =
-        OperationCustomizer { operation, _ ->
+    fun acceptLanguageHeaderCustomizer(): GlobalOperationCustomizer =
+        GlobalOperationCustomizer { operation, _ ->
             operation.apply {
                 addParametersItem(
                     Parameter()
@@ -61,6 +67,30 @@ class OpenApiConfig {
                         .schema(StringSchema()._default("Asia/Seoul")),
                 )
             }
+        }
+
+    @Bean
+    fun apiGroupV1(): GroupedOpenApi =
+        GroupedOpenApi.builder()
+            .group("version-1")
+            .displayName("API version 1")
+            .addOpenApiMethodFilter(versionMethodFilter("1.0"))
+            .build()
+
+    @Bean
+    fun apiGroupV2(): GroupedOpenApi =
+        GroupedOpenApi.builder()
+            .group("version-2")
+            .displayName("API version 2")
+            .addOpenApiMethodFilter(versionMethodFilter("2.0"))
+            .build()
+
+    private fun versionMethodFilter(
+        targetVersion: String,
+    ): OpenApiMethodFilter =
+        OpenApiMethodFilter { method: Method ->
+            val requestMapping = AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping::class.java)
+            requestMapping?.version == targetVersion
         }
 
     companion object {

--- a/src/main/kotlin/com/whatever/caro/common/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/WebMvcConfig.kt
@@ -19,6 +19,8 @@ class WebMvcConfig(
     override fun configureApiVersioning(
         configurer: ApiVersionConfigurer,
     ) {
-        configurer.useRequestHeader("API-Version")
+        configurer
+            .useRequestHeader("API-Version")
+            .setDefaultVersion("1.0")
     }
 }

--- a/src/main/kotlin/com/whatever/caro/common/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/WebMvcConfig.kt
@@ -2,6 +2,7 @@ package com.whatever.caro.common.config
 
 import com.whatever.caro.common.web.idempotency.IdempotencyInterceptor
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
@@ -13,5 +14,11 @@ class WebMvcConfig(
         registry: InterceptorRegistry,
     ) {
         registry.addInterceptor(idempotencyInterceptor)
+    }
+
+    override fun configureApiVersioning(
+        configurer: ApiVersionConfigurer,
+    ) {
+        configurer.useRequestHeader("API-Version")
     }
 }

--- a/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.method.ParameterErrors
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.accept.InvalidApiVersionException
 import org.springframework.web.accept.MissingApiVersionException
@@ -19,6 +20,7 @@ import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.HandlerMethodValidationException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.resource.NoResourceFoundException
@@ -54,6 +56,40 @@ class GlobalExceptionHandler(
         logger.warn { "Validation failed: ${fieldErrors.map { "${it.field}: ${it.message}" }}" }
         return ResponseEntity
             .badRequest()
+            .body(ApiResponse.failValidation(CommonErrorCode.INVALID_INPUT, message, fieldErrors))
+    }
+
+    /**
+     * 메서드 파라미터에 제약(`@Positive` 등)이 직접 붙은 핸들러의 검증 실패
+     *
+     * Spring 6.1+ 내장 메서드 검증은 제약이 하나라도 있으면
+     * 같은 메서드의 `@Valid @RequestBody` 까지 메서드 레벨에서 검증하므로 해당 예외로 발생
+     */
+    @ExceptionHandler(HandlerMethodValidationException::class)
+    fun handleMethodValidation(
+        e: HandlerMethodValidationException,
+        locale: Locale,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val fieldErrors = e.parameterValidationResults.flatMap { result ->
+            when (result) {
+                // @Valid로 중첩된 객체의 오류는 원래 필드명을 그대로 사용
+                is ParameterErrors -> result.fieldErrors.map { error ->
+                    FieldError(field = error.field, message = error.defaultMessage ?: "유효하지 않은 값입니다")
+                }
+
+                // 파라미터(@PathVariable 등)의 오류는 파라미터명을 필드명으로 사용
+                else -> result.resolvableErrors.map { error ->
+                    FieldError(
+                        field = result.methodParameter.parameterName ?: "unknown",
+                        message = messageSource.getMessage(error, locale),
+                    )
+                }
+            }
+        }
+        val message = resolveMessage(CommonErrorCode.INVALID_INPUT, null, locale)
+        logger.warn { "Method validation failed: ${fieldErrors.map { "${it.field}: ${it.message}" }}" }
+        return ResponseEntity
+            .status(e.statusCode)
             .body(ApiResponse.failValidation(CommonErrorCode.INVALID_INPUT, message, fieldErrors))
     }
 

--- a/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
@@ -6,15 +6,21 @@ import com.whatever.caro.common.response.ErrorCodeSpec
 import com.whatever.caro.common.response.FieldError
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.MessageSource
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.accept.InvalidApiVersionException
+import org.springframework.web.accept.MissingApiVersionException
+import org.springframework.web.accept.NotAcceptableApiVersionException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import java.util.Locale
 
@@ -142,6 +148,87 @@ class GlobalExceptionHandler(
             )
     }
 
+    @ExceptionHandler(MissingApiVersionException::class)
+    fun handleMissingApiVersion(
+        e: MissingApiVersionException,
+        locale: Locale,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        logger.warn { "Missing API version" }
+        return ResponseEntity
+            .status(e.statusCode)
+            .body(
+                ApiResponse.fail(
+                    CommonErrorCode.MISSING_API_VERSION,
+                    resolveMessage(CommonErrorCode.MISSING_API_VERSION, null, locale),
+                ),
+            )
+    }
+
+    /**
+     * 요청 버전은 유효하지만, 해당 엔드포인트가 그 버전을 제공하지 않는 경우
+     */
+    @ExceptionHandler(NotAcceptableApiVersionException::class)
+    fun handleNotAcceptableApiVersion(
+        e: NotAcceptableApiVersionException,
+        locale: Locale,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val version = e.version.take(MAX_VERSION_LENGTH)
+        logger.warn { "API version not supported by endpoint: $version" }
+        return ResponseEntity
+            .status(e.statusCode)
+            .body(
+                ApiResponse.fail(
+                    CommonErrorCode.UNSUPPORTED_API_VERSION,
+                    resolveMessage(CommonErrorCode.UNSUPPORTED_API_VERSION, arrayOf(version), locale),
+                ),
+            )
+    }
+
+    @ExceptionHandler(InvalidApiVersionException::class)
+    fun handleInvalidApiVersion(
+        e: InvalidApiVersionException,
+        locale: Locale,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val version = e.version.take(MAX_VERSION_LENGTH)
+        logger.warn { "Invalid API version: $version" }
+        return ResponseEntity
+            .status(e.statusCode)
+            .body(
+                ApiResponse.fail(
+                    CommonErrorCode.INVALID_API_VERSION,
+                    resolveMessage(CommonErrorCode.INVALID_API_VERSION, arrayOf(version), locale),
+                ),
+            )
+    }
+
+    @ExceptionHandler(ResponseStatusException::class)
+    fun handleResponseStatus(
+        e: ResponseStatusException,
+        locale: Locale,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val errorCode = errorCodeFor(e.statusCode)
+        if (e.statusCode.is5xxServerError) {
+            logger.error(e) { "Response status exception (${e.statusCode})" }
+        } else {
+            logger.warn { "Response status exception (${e.statusCode}): ${e.reason}" }
+        }
+        return ResponseEntity
+            .status(e.statusCode)
+            .headers(e.headers)
+            .body(ApiResponse.fail(errorCode, resolveMessage(errorCode, null, locale)))
+    }
+
+    /** 상태 코드에 대응하는 에러 코드가 있으면 그것을 쓰고, 없으면 4xx/5xx 기본값으로 떨어진다. */
+    private fun errorCodeFor(
+        status: HttpStatusCode,
+    ): ErrorCodeSpec =
+        when {
+            status.is5xxServerError -> CommonErrorCode.INTERNAL_ERROR
+            status.value() == HttpStatus.NOT_FOUND.value() -> CommonErrorCode.NOT_FOUND
+            status.value() == HttpStatus.METHOD_NOT_ALLOWED.value() -> CommonErrorCode.METHOD_NOT_ALLOWED
+            else -> CommonErrorCode.INVALID_REQUEST
+        }
+
     @ExceptionHandler(Exception::class)
     fun handleUnexpected(
         e: Exception,
@@ -163,4 +250,9 @@ class GlobalExceptionHandler(
         args: Array<Any>?,
         locale: Locale,
     ): String = messageSource.getMessage(errorCode.messageKey, args, errorCode.message, locale) ?: errorCode.message
+
+    companion object {
+        /** 클라이언트가 보낸 API 버전 문자열을 응답/로그에 반영할 때의 최대 길이 */
+        private const val MAX_VERSION_LENGTH = 32
+    }
 }

--- a/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/whatever/caro/common/exception/GlobalExceptionHandler.kt
@@ -184,6 +184,10 @@ class GlobalExceptionHandler(
             )
     }
 
+    /**
+     * API-Version Header의 default값을 WebMvcConfig에서 설정되어있음.
+     * 해당 설정으로 인해, 이 Handler는 실행되지 않음.
+     */
     @ExceptionHandler(MissingApiVersionException::class)
     fun handleMissingApiVersion(
         e: MissingApiVersionException,

--- a/src/main/kotlin/com/whatever/caro/common/response/CommonErrorCode.kt
+++ b/src/main/kotlin/com/whatever/caro/common/response/CommonErrorCode.kt
@@ -33,5 +33,23 @@ enum class CommonErrorCode(
         "이전 요청이 처리 중입니다. 잠시 후 다시 시도해주세요",
         "error.common.idempotency_request_in_progress",
     ),
+    MISSING_API_VERSION(
+        "C011",
+        HttpStatus.BAD_REQUEST,
+        "API 버전이 누락되었습니다",
+        "error.common.missing_api_version",
+    ),
+    INVALID_API_VERSION(
+        "C012",
+        HttpStatus.BAD_REQUEST,
+        "유효하지 않은 API 버전입니다: {0}",
+        "error.common.invalid_api_version",
+    ),
+    UNSUPPORTED_API_VERSION(
+        "C013",
+        HttpStatus.BAD_REQUEST,
+        "해당 엔드포인트가 지원하지 않는 API 버전입니다: {0}",
+        "error.common.unsupported_api_version",
+    ),
     INTERNAL_ERROR("C999", HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다", "error.common.internal_error"),
 }

--- a/src/main/kotlin/com/whatever/caro/nickname/internal/web/NicknameController.kt
+++ b/src/main/kotlin/com/whatever/caro/nickname/internal/web/NicknameController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Nickname", description = "닉네임 추천")
 @RestController
-@RequestMapping("/v1/nicknames")
+@RequestMapping("/nicknames")
 class NicknameController(
     private val nicknameService: NicknameApi,
 ) {
@@ -22,7 +22,7 @@ class NicknameController(
         summary = "랜덤 닉네임 1개 발급",
         description = "Accept-Language 헤더 로케일에 맞춘 랜덤 닉네임을 반환한다.",
     )
-    @GetMapping("/random")
+    @GetMapping("/random", version = "1.0")
     fun getRandomNickname(): ResponseEntity<ApiResponse<NicknameResponse>> {
         val locale = LocaleContextHolder.getLocale()
         val nickname = nicknameService.randomName(locale)

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/EvaluationController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/EvaluationController.kt
@@ -24,7 +24,7 @@ import java.time.ZoneId
 
 @Tag(name = "StudySession", description = "일일학습 세션 / 평가")
 @RestController
-@RequestMapping("/v1/study-sessions")
+@RequestMapping("/study-sessions")
 class EvaluationController(
     private val clock: Clock,
     private val evaluationService: EvaluationService,
@@ -43,7 +43,7 @@ class EvaluationController(
         """,
     )
     @Idempotent
-    @PostMapping("/{sessionId}/evaluations")
+    @PostMapping("/{sessionId}/evaluations", version = "1.0")
     fun evaluate(
         @RequestHeader("Idempotency-Key", required = true) idempotencyKey: String,
         @RequestHeader("Client-Timezone", required = true) clientTimezone: ZoneId,

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StreakController.kt
@@ -20,7 +20,7 @@ import java.time.ZoneId
 
 @Tag(name = "Streak", description = "연속 학습(streak)")
 @RestController
-@RequestMapping("/v1/streaks")
+@RequestMapping("/streaks")
 class StreakController(
     private val clock: Clock,
     private val streakService: StreakService,
@@ -30,7 +30,7 @@ class StreakController(
         summary = "현재 streak 조회",
         description = "오늘이 휴식일(모든 학습 활성 덱의 due=0)이면 휴식일을 기록한 뒤 현재 streak을 반환한다.",
     )
-    @GetMapping
+    @GetMapping(version = "1.0")
     fun getStreak(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
     ): ResponseEntity<ApiResponse<StreakResponse>> {
@@ -68,7 +68,7 @@ class StreakController(
         오프라인 학습 후 재접속 시 클라이언트가 호출해 서버 streak을 최신 상태로 맞추는 용도이다.
         """,
     )
-    @PostMapping("/sync")
+    @PostMapping("/sync", version = "1.0")
     fun syncStreak(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
     ): ResponseEntity<ApiResponse<Unit>> {

--- a/src/main/kotlin/com/whatever/caro/study/internal/web/StudyController.kt
+++ b/src/main/kotlin/com/whatever/caro/study/internal/web/StudyController.kt
@@ -19,7 +19,7 @@ import java.time.ZoneId
 
 @Tag(name = "StudySession", description = "일일학습 세션 / 평가")
 @RestController
-@RequestMapping("/v1/study-sessions")
+@RequestMapping("/study-sessions")
 class StudyController(
     private val clock: Clock,
     private val studyService: StudyService,
@@ -33,7 +33,7 @@ class StudyController(
         각 상태에서 학습한 카드 수와 오늘 목표 카드 수를 함께 제공한다.
         """,
     )
-    @GetMapping("/daily/summary")
+    @GetMapping("/daily/summary", version = "1.0")
     fun getTodayDailyStudySummary(
         @RequestHeader("Client-Timezone") timezone: ZoneId,
         @RequestParam(value = "deckId", required = true) deckId: Long,

--- a/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
+++ b/src/main/kotlin/com/whatever/caro/user/internal/web/UserController.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "User", description = "사용자 정보 조회")
 @Validated
 @RestController
-@RequestMapping("/v1/users")
+@RequestMapping("/users")
 class UserController(
     private val userApi: UserApi,
     private val userService: UserService,
@@ -37,7 +37,7 @@ class UserController(
         summary = "닉네임 사용 가능 여부 조회",
         description = "닉네임 중복 여부를 반환한다. 길이 제한 50자.",
     )
-    @GetMapping("/nicknames/{nickname}/availability")
+    @GetMapping("/nicknames/{nickname}/availability", version = "1.0")
     fun checkNicknameAvailability(
         @PathVariable
         @NotBlank(message = "Nickname is required")
@@ -52,7 +52,7 @@ class UserController(
         summary = "내 정보 조회",
         description = "현재 로그인한 사용자의 정보를 반환한다.",
     )
-    @GetMapping("/me/info")
+    @GetMapping("/me/info", version = "1.0")
     fun getMyInfo(
         @AuthenticationPrincipal(expression = "userId")
         userId: Long,
@@ -65,7 +65,7 @@ class UserController(
         summary = "닉네임 변경",
         description = "현재 로그인한 사용자의 닉네임을 변경한다.",
     )
-    @PatchMapping("/me/nickname")
+    @PatchMapping("/me/nickname", version = "1.0")
     fun updateNickname(
         @Valid @RequestBody request: UpdateNicknameRequest,
         @AuthenticationPrincipal(expression = "userId")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -131,6 +131,7 @@ springdoc:
     operations-sorter: alpha
     tags-sorter: alpha
     display-request-duration: true
+    urls-primary-name: version-1
   packages-to-scan: com.whatever.caro
   default-produces-media-type: application/json
   default-consumes-media-type: application/json

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -9,6 +9,9 @@ error.common.missing_header=Required header is missing: {0}
 error.common.invalid_idempotency_key=Invalid Idempotency-Key format
 error.common.idempotency_key_conflict=Idempotency-Key already used with a different request
 error.common.idempotency_request_in_progress=A previous request is still being processed
+error.common.missing_api_version=API version is required
+error.common.invalid_api_version=Invalid API version: {0}
+error.common.unsupported_api_version=API version not supported by this endpoint: {0}
 error.common.internal_error=An unexpected error occurred
 # Auth
 error.auth.unauthorized=Authentication required

--- a/src/main/resources/messages_ko.properties
+++ b/src/main/resources/messages_ko.properties
@@ -9,6 +9,9 @@ error.common.missing_header=필수 헤더가 누락되었습니다: {0}
 error.common.invalid_idempotency_key=유효하지 않은 Idempotency-Key 형식입니다
 error.common.idempotency_key_conflict=동일한 Idempotency-Key로 다른 요청이 처리되었습니다
 error.common.idempotency_request_in_progress=이전 요청이 처리 중입니다. 잠시 후 다시 시도해주세요
+error.common.missing_api_version=API 버전이 누락되었습니다
+error.common.invalid_api_version=유효하지 않은 API 버전입니다: {0}
+error.common.unsupported_api_version=해당 엔드포인트가 지원하지 않는 API 버전입니다: {0}
 error.common.internal_error=내부 서버 오류가 발생했습니다
 # Auth
 error.auth.unauthorized=인증이 필요합니다

--- a/src/test/kotlin/com/whatever/caro/bff/internal/web/DeckBFFControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/whatever/caro/bff/internal/web/DeckBFFControllerWebMvcTest.kt
@@ -73,12 +73,14 @@ class DeckBFFControllerWebMvcTest : DescribeSpec() {
             SecurityContextHolder.clearContext()
         }
 
-        describe("GET /v2/decks/{deckId}/cards - sortType 바인딩") {
+        describe("GET /decks/{deckId}/cards (v2) - sortType 바인딩") {
             it("sortType을 생략하면 기본값 CREATED로 서비스에 전달한다") {
                 given(deckBFFService.getCardsWithLearningState(1L, 1L, CardSortType.CREATED))
                     .willReturn(emptyList())
 
-                mockMvc.get("/v2/decks/1/cards").andExpect {
+                mockMvc.get("/decks/1/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
+                }.andExpect {
                     status { isOk() }
                 }
 
@@ -93,7 +95,8 @@ class DeckBFFControllerWebMvcTest : DescribeSpec() {
                 given(deckBFFService.getCardsWithLearningState(1L, 1L, CardSortType.LAST_REVIEWED))
                     .willReturn(emptyList())
 
-                mockMvc.get("/v2/decks/1/cards") {
+                mockMvc.get("/decks/1/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     param("sortType", "LAST_REVIEWED")
                 }.andExpect {
                     status { isOk() }
@@ -107,12 +110,20 @@ class DeckBFFControllerWebMvcTest : DescribeSpec() {
             }
 
             it("유효하지 않은 sortType이면 400을 반환한다") {
-                mockMvc.get("/v2/decks/1/cards") {
+                mockMvc.get("/decks/1/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     param("sortType", "INVALID")
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(TYPE_MISMATCH_CODE) }
                 }
             }
         }
+    }
+
+    companion object {
+        private const val API_VERSION_HEADER = "API-Version"
+        private const val API_VERSION = "2.0"
+        private const val TYPE_MISMATCH_CODE = "C006"
     }
 }

--- a/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/card/CardControllerWebMvcTest.kt
@@ -68,77 +68,98 @@ class CardControllerWebMvcTest : DescribeSpec() {
             SecurityContextHolder.clearContext()
         }
 
-        describe("POST /v1/decks/{deckId}/cards - @Valid 검증") {
+        describe("POST /decks/{deckId}/cards - @Valid 검증") {
             it("items 가 비어있으면 400 을 반환한다") {
-                mockMvc.post("/v1/decks/1/cards") {
+                mockMvc.post("/decks/1/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"items": []}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
 
             it("item 의 fields 가 비어있으면 400 을 반환한다") {
-                mockMvc.post("/v1/decks/1/cards") {
+                mockMvc.post("/decks/1/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"items": [{"cardType": "BASIC", "fields": {}}]}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
         }
 
-        describe("PATCH /v1/cards/{id} - @Valid 검증") {
+        describe("PATCH /cards/{id} - @Valid 검증") {
             it("fields 가 비어있으면 400 을 반환한다") {
-                mockMvc.patch("/v1/cards/1") {
+                mockMvc.patch("/cards/1") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"fields": {}}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
         }
 
-        describe("DELETE /v1/cards - @Valid 검증") {
+        describe("DELETE /cards - @Valid 검증") {
             it("cardIds 가 비어있으면 400 을 반환한다") {
-                mockMvc.delete("/v1/cards") {
+                mockMvc.delete("/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     header("Client-Timezone", "Asia/Seoul")
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"cardIds": []}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
 
             it("cardIds 가 1000개를 초과하면 400 을 반환한다") {
                 val ids = (1..1001).joinToString(",")
-                mockMvc.delete("/v1/cards") {
+                mockMvc.delete("/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     header("Client-Timezone", "Asia/Seoul")
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"cardIds": [$ids]}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
 
             it("cardIds 에 0 이하가 섞이면 400 을 반환한다") {
-                mockMvc.delete("/v1/cards") {
+                mockMvc.delete("/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     header("Client-Timezone", "Asia/Seoul")
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"cardIds": [1, 0]}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
 
             it("Client-Timezone 헤더가 없으면 400 을 반환한다") {
-                mockMvc.delete("/v1/cards") {
+                mockMvc.delete("/cards") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"cardIds": [1]}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(MISSING_HEADER_CODE) }
                 }
             }
         }
+    }
+
+    companion object {
+        private const val API_VERSION_HEADER = "API-Version"
+        private const val API_VERSION = "1.0"
+        private const val INVALID_INPUT_CODE = "C001"
+        private const val MISSING_HEADER_CODE = "C007"
     }
 }

--- a/src/test/kotlin/com/whatever/caro/card/internal/deck/controller/DeckControllerWebMvcTest.kt
+++ b/src/test/kotlin/com/whatever/caro/card/internal/deck/controller/DeckControllerWebMvcTest.kt
@@ -68,44 +68,58 @@ class DeckControllerWebMvcTest : DescribeSpec() {
             SecurityContextHolder.clearContext()
         }
 
-        describe("POST /v1/decks - @Valid 검증") {
+        describe("POST /decks - @Valid 검증") {
             it("name이 blank면 400을 반환한다") {
-                mockMvc.post("/v1/decks") {
+                mockMvc.post("/decks") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"name": "", "description": "설명"}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
 
             it("description이 blank면 400을 반환한다") {
-                mockMvc.post("/v1/decks") {
+                mockMvc.post("/decks") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"name": "새 덱", "description": ""}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
         }
 
-        describe("PATCH /v1/decks/{deckId} - @Valid 검증") {
+        describe("PATCH /decks/{deckId} - @Valid 검증") {
             it("name이 blank면 400을 반환한다") {
-                mockMvc.patch("/v1/decks/1") {
+                mockMvc.patch("/decks/1") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"name": "", "description": "새 설명"}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
 
             it("description이 blank면 400을 반환한다") {
-                mockMvc.patch("/v1/decks/1") {
+                mockMvc.patch("/decks/1") {
+                    header(API_VERSION_HEADER, API_VERSION)
                     contentType = MediaType.APPLICATION_JSON
                     content = """{"name": "새 이름", "description": ""}"""
                 }.andExpect {
                     status { isBadRequest() }
+                    jsonPath("$.error.code") { value(INVALID_INPUT_CODE) }
                 }
             }
         }
+    }
+
+    companion object {
+        private const val API_VERSION_HEADER = "API-Version"
+        private const val API_VERSION = "1.0"
+        private const val INVALID_INPUT_CODE = "C001"
     }
 }


### PR DESCRIPTION
## 📌 Related Issue

## 📝 Changes
spring framework 7부터 지원하는 내장 api 버저닝을 적용했습니다.
URL에 prefix로 사용하던 `/v1`을 제거하고, `API-Version` 헤더를 사용합니다.
> 모든 요청에 해당 헤더가 필요하며, 필요 시 default version을 지정해 완화 가능합니다.

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)
- `@Validated` 제거
- SecurityConfig 인가 url 오타 수정(`/users/nickname/**` -> `users/nicknames/**`)