### PR TITLE
[Feat] deprecated를 제외한 전체 api를 볼 수 있는 swagger api group 추가

### DIFF
--- a/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.customizers.GlobalOperationCustomizer
-import org.springdoc.core.customizers.OperationCustomizer
 import org.springdoc.core.filters.OpenApiMethodFilter
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
@@ -68,6 +67,17 @@ class OpenApiConfig {
                 )
             }
         }
+
+    @Bean
+    fun apiGroupAll(): GroupedOpenApi =
+        GroupedOpenApi.builder()
+            .group("all-version")
+            .displayName("All API version")
+            .addOpenApiMethodFilter { method: Method ->
+                val deprecated = AnnotatedElementUtils.findMergedAnnotation(method, Deprecated::class.java)
+                deprecated == null
+            }
+            .build()
 
     @Bean
     fun apiGroupV1(): GroupedOpenApi =

--- a/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/whatever/caro/common/config/OpenApiConfig.kt
@@ -69,6 +69,24 @@ class OpenApiConfig {
         }
 
     @Bean
+    fun apiVersionDefaultCustomizer(): GlobalOperationCustomizer =
+        GlobalOperationCustomizer { operation, handlerMethod ->
+            val version = AnnotatedElementUtils.findMergedAnnotation(
+                handlerMethod.method,
+                RequestMapping::class.java,
+            )?.version?.takeIf { it.isNotBlank() }?.removeSuffix("+")
+
+            val parameter = operation.parameters?.firstOrNull { it.name == "API-Version" && it.`in` == "header" }
+
+            if (version != null && parameter != null) {
+                parameter.required = true
+                parameter.schema.default = version
+            }
+
+            operation
+        }
+
+    @Bean
     fun apiGroupAll(): GroupedOpenApi =
         GroupedOpenApi.builder()
             .group("all-version")


### PR DESCRIPTION
## 📌 Related Issue
Closes #

## 📝 Changes
- 클라이언트 팀 요청으로 `RequestMapping` method에서 `Deprecated` annotation이 붙은 method를 제외한 모든 버전이 들어가는 group을 추가했습니다
- swagger api 버전이 default로 설정해둔 전역 버전으로 고정되던 문제 수정

## ✅ Checklist
- [x] 테스트 완료
- [x] 리뷰 준비 완료

## 📋 Additional Notes(Optional)